### PR TITLE
Mock API modules

### DIFF
--- a/lib/api/alphanames.ts
+++ b/lib/api/alphanames.ts
@@ -1,10 +1,48 @@
 // lib/api/alphanames.ts
 
 // Импортируй Axios или используй fetch (пример будет на fetch)
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://your.external.api/v1"
+// const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://your.external.api/v1"
 
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
+const mockAlphanames: Alphaname[] = [
+  {
+    id: "1",
+    alpha_name: "TEST",
+    ctn: "9000",
+    system_id: "20100",
+    active: true,
+    bind_mode: "mode",
+    alias: "t",
+    ip_address: "127.0.0.1",
+    description: "mock",
+    created_at: "2024-01-01",
+    updated_at: "2024-01-02",
+  },
+]
+
+export const alphanamesAPI = {
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockAlphanames.find((a) => a.id === id) || ({} as Alphaname)
+    ),
+  // create: (data: any) =>
+  //   fetchProtected(`/admin/main/alphanamemodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: any) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: any) =>
+  //   fetchProtected(`/admin/main/alphanamemodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: any) => Promise.resolve({ status: 200 }),
+  list: async () => Promise.resolve(mockAlphanames),
+  // ... другие методы
+}
+
+/*
 export const alphanamesAPI = {
   getById: (id: string) => fetchProtected(`/admin/main/alphanamemodel/${id}`),
   create: (data: any) =>
@@ -18,8 +56,8 @@ export const alphanamesAPI = {
       body: JSON.stringify(data),
     }),
   list: () => fetchProtected(`/admin/main/alphanamemodel/`),
-  // ... другие методы
 }
+*/
 
 // Типизация (можно вынести отдельно)
 export type Alphaname = {

--- a/lib/api/an-patterns.ts
+++ b/lib/api/an-patterns.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type ANPattern = {
   id: string
@@ -17,27 +17,71 @@ export type ANPattern = {
   updated_by?: string
 }
 
+const mockANPatterns: ANPattern[] = [
+  {
+    id: "1",
+    system_id: "20100",
+    ctn: "9000",
+    alpha_name: "TEST",
+    category: "general",
+    name: "pattern1",
+    pattern: "sample",
+    active: true,
+    ip_address: "127.0.0.1",
+    description: "Mock pattern",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
 export const anPatternsAPI = {
-  list: () =>
-    fetchProtected(`/admin/main/anpatternmodel/`),
+  list: async () => Promise.resolve(mockANPatterns),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockANPatterns.find((p) => p.id === id) || ({} as ANPattern)
+    ),
 
-  getById: (id: string) =>
-    fetchProtected(`/admin/main/anpatternmodel/${id}/`),
+  // create: (data: Partial<ANPattern>) =>
+  //   fetchProtected(`/admin/main/anpatternmodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: Partial<ANPattern>) => Promise.resolve({ status: 200 }),
 
+  // update: (id: string, data: Partial<ANPattern>) =>
+  //   fetchProtected(`/admin/main/anpatternmodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: Partial<ANPattern>) =>
+    Promise.resolve({ status: 200 }),
+
+  // delete: (id: string) =>
+  //   fetchProtected(`/admin/main/anpatternmodel/${id}/`, {
+  //     method: "DELETE",
+  //   }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}
+
+/*
+export const anPatternsAPI = {
+  list: () => fetchProtected(`/admin/main/anpatternmodel/`),
+  getById: (id: string) => fetchProtected(`/admin/main/anpatternmodel/${id}/`),
   create: (data: Partial<ANPattern>) =>
     fetchProtected(`/admin/main/anpatternmodel/`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
-
   update: (id: string, data: Partial<ANPattern>) =>
     fetchProtected(`/admin/main/anpatternmodel/${id}/`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
-
   delete: (id: string) =>
     fetchProtected(`/admin/main/anpatternmodel/${id}/`, {
       method: "DELETE",
     }),
 }
+*/

--- a/lib/api/audit-logs.ts
+++ b/lib/api/audit-logs.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type AuditLog = {
   id: string
@@ -10,30 +10,67 @@ export type AuditLog = {
   changes: string
 }
 
-export const auditLogsAPI = {
-  list: () =>
-    fetchProtected(`/admin/main/auditlogmodel/`),
+const mockAuditLogs: AuditLog[] = [
+  {
+    id: "1",
+    user: "admin",
+    timestamp: "2024-01-01T00:00:00Z",
+    action: "create",
+    table: "partners",
+    object: "1",
+    changes: "{}",
+  },
+]
 
-  getById: (id: string) =>
-    fetchProtected(`/admin/main/auditlogmodel/${id}/`),
+export const auditLogsAPI = {
+  list: async () => Promise.resolve(mockAuditLogs),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockAuditLogs.find((l) => l.id === id) || ({} as AuditLog)
+    ),
 
   // Чаще всего audit logs нельзя создавать/редактировать с фронта,
   // но если нужно, добавь методы ниже.
 
+  // create: (data: Partial<AuditLog>) =>
+  //   fetchProtected(`/admin/main/auditlogmodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: Partial<AuditLog>) => Promise.resolve({ status: 200 }),
+
+  // update: (id: string, data: Partial<AuditLog>) =>
+  //   fetchProtected(`/admin/main/auditlogmodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: Partial<AuditLog>) =>
+    Promise.resolve({ status: 200 }),
+
+  // delete: (id: string) =>
+  //   fetchProtected(`/admin/main/auditlogmodel/${id}/`, {
+  //     method: "DELETE",
+  //   }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}
+
+/*
+export const auditLogsAPI = {
+  list: () => fetchProtected(`/admin/main/auditlogmodel/`),
+  getById: (id: string) => fetchProtected(`/admin/main/auditlogmodel/${id}/`),
   create: (data: Partial<AuditLog>) =>
     fetchProtected(`/admin/main/auditlogmodel/`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
-
   update: (id: string, data: Partial<AuditLog>) =>
     fetchProtected(`/admin/main/auditlogmodel/${id}/`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
-
   delete: (id: string) =>
     fetchProtected(`/admin/main/auditlogmodel/${id}/`, {
       method: "DELETE",
     }),
 }
+*/

--- a/lib/api/category-mt.ts
+++ b/lib/api/category-mt.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type CategoryMT = {
   id: string
@@ -12,28 +12,67 @@ export type CategoryMT = {
   updated_by?: string
 }
 
+const mockCategoryMT: CategoryMT[] = [
+  {
+    id: "1",
+    name: "info",
+    ip_address: "127.0.0.1",
+    cdr: "0",
+    sms_type_number: "1",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
 export const categoryMTAPI = {
-  list: () =>
-    fetchProtected(`/admin/main/categorymtmodel/`),
+  list: async () => Promise.resolve(mockCategoryMT),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockCategoryMT.find((c) => c.id === id) || ({} as CategoryMT)
+    ),
 
-  getById: (id: string) =>
-    fetchProtected(`/admin/main/categorymtmodel/${id}/`),
+  // create: (data: Partial<CategoryMT>) =>
+  //   fetchProtected(`/admin/main/categorymtmodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: Partial<CategoryMT>) => Promise.resolve({ status: 200 }),
 
+  // update: (id: string, data: Partial<CategoryMT>) =>
+  //   fetchProtected(`/admin/main/categorymtmodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: Partial<CategoryMT>) =>
+    Promise.resolve({ status: 200 }),
+
+  // delete: (id: string) =>
+  //   fetchProtected(`/admin/main/categorymtmodel/${id}/`, {
+  //     method: "DELETE",
+  //   }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}
+
+/*
+export const categoryMTAPI = {
+  list: () => fetchProtected(`/admin/main/categorymtmodel/`),
+  getById: (id: string) => fetchProtected(`/admin/main/categorymtmodel/${id}/`),
   create: (data: Partial<CategoryMT>) =>
     fetchProtected(`/admin/main/categorymtmodel/`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
-
   update: (id: string, data: Partial<CategoryMT>) =>
     fetchProtected(`/admin/main/categorymtmodel/${id}/`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
-
   delete: (id: string) =>
     fetchProtected(`/admin/main/categorymtmodel/${id}/`, {
       method: "DELETE",
     }),
 }
+*/
 

--- a/lib/api/cdr-settings.ts
+++ b/lib/api/cdr-settings.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type CDRSetting = {
   id: string
@@ -8,27 +8,62 @@ export type CDRSetting = {
   event_type: string
 }
 
+const mockCDRSettings: CDRSetting[] = [
+  {
+    id: "1",
+    cdr_setting: "default",
+    sms_process_batch: "10",
+    generation_time_value: "5m",
+    event_type: "MO",
+  },
+]
+
 export const cdrSettingsAPI = {
-  list: () =>
-    fetchProtected(`/admin/main/cdrsettingsmodel/`),
+  list: async () => Promise.resolve(mockCDRSettings),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockCDRSettings.find((c) => c.id === id) || ({} as CDRSetting)
+    ),
 
-  getById: (id: string) =>
-    fetchProtected(`/admin/main/cdrsettingsmodel/${id}/`),
+  // create: (data: Partial<CDRSetting>) =>
+  //   fetchProtected(`/admin/main/cdrsettingsmodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: Partial<CDRSetting>) => Promise.resolve({ status: 200 }),
 
+  // update: (id: string, data: Partial<CDRSetting>) =>
+  //   fetchProtected(`/admin/main/cdrsettingsmodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: Partial<CDRSetting>) =>
+    Promise.resolve({ status: 200 }),
+
+  // delete: (id: string) =>
+  //   fetchProtected(`/admin/main/cdrsettingsmodel/${id}/`, {
+  //     method: "DELETE",
+  //   }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}
+
+/*
+export const cdrSettingsAPI = {
+  list: () => fetchProtected(`/admin/main/cdrsettingsmodel/`),
+  getById: (id: string) => fetchProtected(`/admin/main/cdrsettingsmodel/${id}/`),
   create: (data: Partial<CDRSetting>) =>
     fetchProtected(`/admin/main/cdrsettingsmodel/`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
-
   update: (id: string, data: Partial<CDRSetting>) =>
     fetchProtected(`/admin/main/cdrsettingsmodel/${id}/`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
-
   delete: (id: string) =>
     fetchProtected(`/admin/main/cdrsettingsmodel/${id}/`, {
       method: "DELETE",
     }),
 }
+*/

--- a/lib/api/ctns.ts
+++ b/lib/api/ctns.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type CTN = {
   id: string
@@ -14,22 +14,56 @@ export type CTN = {
   updated_by?: string
 }
 
+const mockCTNs: CTN[] = [
+  {
+    id: "1",
+    system_id: "sys_001",
+    category: "A",
+    ctn: "12345",
+    ip_address: "127.0.0.1",
+    active: true,
+    description: "Mock ctn",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
 export const ctnAPI = {
-  list: () =>
-    fetchProtected(`/admin/main/ctnmodel/`),
+  list: async () => Promise.resolve(mockCTNs),
+  getById: async (id: string) =>
+    Promise.resolve(mockCTNs.find((c) => c.id === id) || ({} as CTN)),
 
-  getById: (id: string) =>
-    fetchProtected(`/admin/main/ctnmodel/${id}/`),
+  // create: (data: Partial<CTN>) =>
+  //   fetchProtected(`/admin/main/ctnmodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: Partial<CTN>) => Promise.resolve({ status: 200 }),
 
+  // update: (id: string, data: Partial<CTN>) =>
+  //   fetchProtected(`/admin/main/ctnmodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: Partial<CTN>) =>
+    Promise.resolve({ status: 200 }),
+}
+
+/*
+export const ctnAPI = {
+  list: () => fetchProtected(`/admin/main/ctnmodel/`),
+  getById: (id: string) => fetchProtected(`/admin/main/ctnmodel/${id}/`),
   create: (data: Partial<CTN>) =>
     fetchProtected(`/admin/main/ctnmodel/`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
-
   update: (id: string, data: Partial<CTN>) =>
     fetchProtected(`/admin/main/ctnmodel/${id}/`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
 }
+*/

--- a/lib/api/custom-users.ts
+++ b/lib/api/custom-users.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type CustomUser = {
   id: string
@@ -8,27 +8,62 @@ export type CustomUser = {
   date_joined: string
 }
 
+const mockCustomUsers: CustomUser[] = [
+  {
+    id: "1",
+    username: "mockuser",
+    is_active: true,
+    is_staff: false,
+    date_joined: "2024-01-01",
+  },
+]
+
 export const customUsersAPI = {
-  list: () =>
-    fetchProtected(`/admin/main/customusermodel/`),
+  list: async () => Promise.resolve(mockCustomUsers),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockCustomUsers.find((u) => u.id === id) || ({} as CustomUser)
+    ),
 
-  getById: (id: string) =>
-    fetchProtected(`/admin/main/customusermodel/${id}/`),
+  // create: (data: Partial<CustomUser>) =>
+  //   fetchProtected(`/admin/main/customusermodel/`, {
+  //     method: "POST",
+  //     body: JSON.stringify(data),
+  //   }),
+  create: async (_data: Partial<CustomUser>) => Promise.resolve({ status: 200 }),
 
+  // update: (id: string, data: Partial<CustomUser>) =>
+  //   fetchProtected(`/admin/main/customusermodel/${id}/`, {
+  //     method: "PUT",
+  //     body: JSON.stringify(data),
+  //   }),
+  update: async (_id: string, _data: Partial<CustomUser>) =>
+    Promise.resolve({ status: 200 }),
+
+  // delete: (id: string) =>
+  //   fetchProtected(`/admin/main/customusermodel/${id}/`, {
+  //     method: "DELETE",
+  //   }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}
+
+/*
+export const customUsersAPI = {
+  list: () => fetchProtected(`/admin/main/customusermodel/`),
+  getById: (id: string) => fetchProtected(`/admin/main/customusermodel/${id}/`),
   create: (data: Partial<CustomUser>) =>
     fetchProtected(`/admin/main/customusermodel/`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
-
   update: (id: string, data: Partial<CustomUser>) =>
     fetchProtected(`/admin/main/customusermodel/${id}/`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
-
   delete: (id: string) =>
     fetchProtected(`/admin/main/customusermodel/${id}/`, {
       method: "DELETE",
     }),
 }
+*/

--- a/lib/api/deliver-sm-dlr.ts
+++ b/lib/api/deliver-sm-dlr.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type DeliverSmDLR = {
   id: string
@@ -8,9 +8,41 @@ export type DeliverSmDLR = {
   created_at: string
 }
 
+const mockDeliverSmDLR: DeliverSmDLR[] = [
+  {
+    id: "1",
+    smpp_message_id: "msg001",
+    delivery_status: "delivered",
+    message_content_snippet: "Hello",
+    created_at: "2024-01-01T00:00:00Z",
+  },
+]
+
+export const deliverSmDLRAPI = {
+  list: async () => Promise.resolve(mockDeliverSmDLR),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockDeliverSmDLR.find((d) => d.id === id) || ({} as DeliverSmDLR)
+    ),
+  // create: (data: Partial<DeliverSmDLR>) => fetchProtected(`/admin/main/deliversmdlirmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<DeliverSmDLR>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<DeliverSmDLR>) => fetchProtected(`/admin/main/deliversmdlirmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<DeliverSmDLR>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const deliverSmDLRAPI = {
   list: () => fetchProtected(`/admin/main/deliversmdlirmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/deliversmdlirmodel/${id}/`),
-  create: (data: Partial<DeliverSmDLR>) => fetchProtected(`/admin/main/deliversmdlirmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<DeliverSmDLR>) => fetchProtected(`/admin/main/deliversmdlirmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<DeliverSmDLR>) =>
+    fetchProtected(`/admin/main/deliversmdlirmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<DeliverSmDLR>) =>
+    fetchProtected(`/admin/main/deliversmdlirmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/deliver-sm-p2a.ts
+++ b/lib/api/deliver-sm-p2a.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type DeliverSmP2A = {
   id: string
@@ -8,9 +8,41 @@ export type DeliverSmP2A = {
   created_at: string
 }
 
+const mockDeliverSmP2A: DeliverSmP2A[] = [
+  {
+    id: "1",
+    smpp_message_id: "msg002",
+    delivery_status: "delivered",
+    message_content_snippet: "Hi",
+    created_at: "2024-01-01T01:00:00Z",
+  },
+]
+
+export const deliverSmP2AAPI = {
+  list: async () => Promise.resolve(mockDeliverSmP2A),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockDeliverSmP2A.find((d) => d.id === id) || ({} as DeliverSmP2A)
+    ),
+  // create: (data: Partial<DeliverSmP2A>) => fetchProtected(`/admin/main/deliversmp2amodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<DeliverSmP2A>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<DeliverSmP2A>) => fetchProtected(`/admin/main/deliversmp2amodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<DeliverSmP2A>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const deliverSmP2AAPI = {
   list: () => fetchProtected(`/admin/main/deliversmp2amodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/deliversmp2amodel/${id}/`),
-  create: (data: Partial<DeliverSmP2A>) => fetchProtected(`/admin/main/deliversmp2amodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<DeliverSmP2A>) => fetchProtected(`/admin/main/deliversmp2amodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<DeliverSmP2A>) =>
+    fetchProtected(`/admin/main/deliversmp2amodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<DeliverSmP2A>) =>
+    fetchProtected(`/admin/main/deliversmp2amodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/mo-interceptor-logs.ts
+++ b/lib/api/mo-interceptor-logs.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type MOInterceptorLog = {
   id: string
@@ -11,7 +11,30 @@ export type MOInterceptorLog = {
   modified: string
 }
 
+const mockMOInterceptorLogs: MOInterceptorLog[] = [
+  {
+    id: "1",
+    system_id: "sys_001",
+    source_addr: "1000",
+    destination_addr: "2000",
+    short_message: "test",
+    ip_address: "127.0.0.1",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+  },
+]
+
+export const moInterceptorLogsAPI = {
+  list: async () => Promise.resolve(mockMOInterceptorLogs),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockMOInterceptorLogs.find((l) => l.id === id) || ({} as MOInterceptorLog)
+    ),
+}
+
+/*
 export const moInterceptorLogsAPI = {
   list: () => fetchProtected(`/admin/main/mointerceptorlogmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/mointerceptorlogmodel/${id}/`)
 }
+*/

--- a/lib/api/mo-messages.ts
+++ b/lib/api/mo-messages.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type MOMessages = {
   id: string
@@ -16,9 +16,49 @@ export type MOMessages = {
   delivered_at: string
 }
 
+const mockMOMessages: MOMessages[] = [
+  {
+    id: "1",
+    queue_message_id: "q1",
+    smpp_message_id: "smpp1",
+    source_addr: "1000",
+    destination_addr: "2000",
+    category: "test",
+    submit_status: "ok",
+    submit_resp_status: "0",
+    delivery_status: "delivered",
+    mt_interceptor_log_id: "1",
+    process_status: "done",
+    sent_at: "2024-01-01",
+    delivered_at: "2024-01-01",
+  },
+]
+
+export const moMessagesAPI = {
+  list: async () => Promise.resolve(mockMOMessages),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockMOMessages.find((m) => m.id === id) || ({} as MOMessages)
+    ),
+  // create: (data: Partial<MOMessages>) => fetchProtected(`/admin/main/momessagesmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<MOMessages>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<MOMessages>) => fetchProtected(`/admin/main/momessagesmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<MOMessages>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const moMessagesAPI = {
   list: () => fetchProtected(`/admin/main/momessagesmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/momessagesmodel/${id}/`),
-  create: (data: Partial<MOMessages>) => fetchProtected(`/admin/main/momessagesmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<MOMessages>) => fetchProtected(`/admin/main/momessagesmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<MOMessages>) =>
+    fetchProtected(`/admin/main/momessagesmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<MOMessages>) =>
+    fetchProtected(`/admin/main/momessagesmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/mt-interceptor-logs.ts
+++ b/lib/api/mt-interceptor-logs.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type MTInterceptorLog = {
   id: string
@@ -14,7 +14,33 @@ export type MTInterceptorLog = {
   modified: string
 }
 
+const mockMTInterceptorLogs: MTInterceptorLog[] = [
+  {
+    id: "1",
+    source_addr: "1000",
+    system_id: "sys_001",
+    destination_addr: "2000",
+    ip_address: "127.0.0.1",
+    short_message: "test",
+    category: "info",
+    mt_interceptor_id: "1",
+    category_id: "1",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+  },
+]
+
+export const mtInterceptorLogsAPI = {
+  list: async () => Promise.resolve(mockMTInterceptorLogs),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockMTInterceptorLogs.find((l) => l.id === id) || ({} as MTInterceptorLog)
+    ),
+}
+
+/*
 export const mtInterceptorLogsAPI = {
   list: () => fetchProtected(`/admin/main/mtinterceptorlogmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/mtinterceptorlogmodel/${id}/`)
 }
+*/

--- a/lib/api/mt-messages.ts
+++ b/lib/api/mt-messages.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type MTMessages = {
   id: string
@@ -16,9 +16,49 @@ export type MTMessages = {
   delivered_at: string
 }
 
+const mockMTMessages: MTMessages[] = [
+  {
+    id: "1",
+    queue_message_id: "q1",
+    smpp_message_id: "smpp1",
+    source_addr: "1000",
+    destination_addr: "2000",
+    category: "test",
+    submit_status: "ok",
+    submit_resp_status: "0",
+    delivery_status: "delivered",
+    mt_interceptor_log_id: "1",
+    process_status: "done",
+    sent_at: "2024-01-01",
+    delivered_at: "2024-01-01",
+  },
+]
+
+export const mtMessagesAPI = {
+  list: async () => Promise.resolve(mockMTMessages),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockMTMessages.find((m) => m.id === id) || ({} as MTMessages)
+    ),
+  // create: (data: Partial<MTMessages>) => fetchProtected(`/admin/main/mtmessagesmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<MTMessages>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<MTMessages>) => fetchProtected(`/admin/main/mtmessagesmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<MTMessages>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const mtMessagesAPI = {
   list: () => fetchProtected(`/admin/main/mtmessagesmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/mtmessagesmodel/${id}/`),
-  create: (data: Partial<MTMessages>) => fetchProtected(`/admin/main/mtmessagesmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<MTMessages>) => fetchProtected(`/admin/main/mtmessagesmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<MTMessages>) =>
+    fetchProtected(`/admin/main/mtmessagesmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<MTMessages>) =>
+    fetchProtected(`/admin/main/mtmessagesmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/partners-statistics.ts
+++ b/lib/api/partners-statistics.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type PartnerStatistics = {
   id: string
@@ -8,7 +8,27 @@ export type PartnerStatistics = {
   revenue: string
 }
 
+const mockPartnerStats: PartnerStatistics[] = [
+  {
+    id: "1",
+    partner: "partner_1",
+    messages_sent: "100",
+    success_rate: "99%",
+    revenue: "10",
+  },
+]
+
+export const partnersStatisticsAPI = {
+  list: async () => Promise.resolve(mockPartnerStats),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockPartnerStats.find((p) => p.id === id) || ({} as PartnerStatistics)
+    ),
+}
+
+/*
 export const partnersStatisticsAPI = {
   list: () => fetchProtected(`/admin/main/partnersstatisticsmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/partnersstatisticsmodel/${id}/`)
 }
+*/

--- a/lib/api/partners.ts
+++ b/lib/api/partners.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type Partner = {
   id: string
@@ -13,9 +13,43 @@ export type Partner = {
   updated_by: string
 }
 
+const mockPartners: Partner[] = [
+  {
+    id: "1",
+    system_id: "sys_001",
+    username: "partner_1",
+    active: true,
+    ip_address: "127.0.0.1",
+    description: "Mock partner",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
+export const partnersAPI = {
+  list: async () => Promise.resolve(mockPartners),
+  getById: async (id: string) =>
+    Promise.resolve(mockPartners.find((p) => p.id === id) || ({} as Partner)),
+  create: async (_data: Partial<Partner>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<Partner>) =>
+    Promise.resolve({ status: 200 }),
+}
+
+/*
 export const partnersAPI = {
   list: () => fetchProtected(`/admin/main/partnermodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/partnermodel/${id}/`),
-  create: (data: Partial<Partner>) => fetchProtected(`/admin/main/partnermodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<Partner>) => fetchProtected(`/admin/main/partnermodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<Partner>) =>
+    fetchProtected(`/admin/main/partnermodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<Partner>) =>
+    fetchProtected(`/admin/main/partnermodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/periodic-tesks.ts
+++ b/lib/api/periodic-tesks.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type PeriodicTask = {
   id: string
@@ -11,9 +11,44 @@ export type PeriodicTask = {
   one_off: boolean | string
 }
 
+const mockPeriodicTasks: PeriodicTask[] = [
+  {
+    id: "1",
+    name: "task1",
+    enabled: true,
+    scheduler: "daily",
+    interval_schedule: "24h",
+    start_datetime: "2024-01-01T00:00:00Z",
+    last_run: "2024-01-02T00:00:00Z",
+    one_off: false,
+  },
+]
+
+export const periodicTasksAPI = {
+  list: async () => Promise.resolve(mockPeriodicTasks),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockPeriodicTasks.find((t) => t.id === id) || ({} as PeriodicTask)
+    ),
+  // create: (data: Partial<PeriodicTask>) => fetchProtected(`/admin/main/periodictaskmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<PeriodicTask>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<PeriodicTask>) => fetchProtected(`/admin/main/periodictaskmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<PeriodicTask>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const periodicTasksAPI = {
   list: () => fetchProtected(`/admin/main/periodictaskmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/periodictaskmodel/${id}/`),
-  create: (data: Partial<PeriodicTask>) => fetchProtected(`/admin/main/periodictaskmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<PeriodicTask>) => fetchProtected(`/admin/main/periodictaskmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<PeriodicTask>) =>
+    fetchProtected(`/admin/main/periodictaskmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<PeriodicTask>) =>
+    fetchProtected(`/admin/main/periodictaskmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/regex-patterns.ts
+++ b/lib/api/regex-patterns.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type RegexPattern = {
   id: string
@@ -13,9 +13,46 @@ export type RegexPattern = {
   updated_by: string
 }
 
+const mockRegexPatterns: RegexPattern[] = [
+  {
+    id: "1",
+    variable: "var1",
+    pattern: "^test$",
+    active: true,
+    description: "mock",
+    ip_address: "127.0.0.1",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
+export const regexPatternsAPI = {
+  list: async () => Promise.resolve(mockRegexPatterns),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockRegexPatterns.find((p) => p.id === id) || ({} as RegexPattern)
+    ),
+  // create: (data: Partial<RegexPattern>) => fetchProtected(`/admin/main/regexpatternmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<RegexPattern>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<RegexPattern>) => fetchProtected(`/admin/main/regexpatternmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<RegexPattern>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const regexPatternsAPI = {
   list: () => fetchProtected(`/admin/main/regexpatternmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/regexpatternmodel/${id}/`),
-  create: (data: Partial<RegexPattern>) => fetchProtected(`/admin/main/regexpatternmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<RegexPattern>) => fetchProtected(`/admin/main/regexpatternmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<RegexPattern>) =>
+    fetchProtected(`/admin/main/regexpatternmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<RegexPattern>) =>
+    fetchProtected(`/admin/main/regexpatternmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/shn-patterns.ts
+++ b/lib/api/shn-patterns.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type SHNPattern = {
   id: string
@@ -16,9 +16,49 @@ export type SHNPattern = {
   updated_by: string
 }
 
+const mockSHNPatterns: SHNPattern[] = [
+  {
+    id: "1",
+    system_id: "sys_001",
+    short_number: "1111",
+    category: "info",
+    name: "pattern1",
+    pattern: "sample",
+    active: true,
+    ip_address: "127.0.0.1",
+    description: "mock",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
+export const shnPatternsAPI = {
+  list: async () => Promise.resolve(mockSHNPatterns),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockSHNPatterns.find((p) => p.id === id) || ({} as SHNPattern)
+    ),
+  // create: (data: Partial<SHNPattern>) => fetchProtected(`/admin/main/shnpatternmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<SHNPattern>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<SHNPattern>) => fetchProtected(`/admin/main/shnpatternmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<SHNPattern>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const shnPatternsAPI = {
   list: () => fetchProtected(`/admin/main/shnpatternmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/shnpatternmodel/${id}/`),
-  create: (data: Partial<SHNPattern>) => fetchProtected(`/admin/main/shnpatternmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<SHNPattern>) => fetchProtected(`/admin/main/shnpatternmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<SHNPattern>) =>
+    fetchProtected(`/admin/main/shnpatternmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<SHNPattern>) =>
+    fetchProtected(`/admin/main/shnpatternmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/short-numbers.ts
+++ b/lib/api/short-numbers.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type ShortNumber = {
   id: string
@@ -16,9 +16,49 @@ export type ShortNumber = {
   updated_by: string
 }
 
+const mockShortNumbers: ShortNumber[] = [
+  {
+    id: "1",
+    system_id: "sys_001",
+    ctn: "12345",
+    short_number: "1111",
+    active: true,
+    bind_mode: "bind",
+    alias: "short",
+    ip_address: "127.0.0.1",
+    description: "mock",
+    created: "2024-01-01",
+    modified: "2024-01-02",
+    created_by: "admin",
+    updated_by: "admin",
+  },
+]
+
+export const shortNumbersAPI = {
+  list: async () => Promise.resolve(mockShortNumbers),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockShortNumbers.find((n) => n.id === id) || ({} as ShortNumber)
+    ),
+  // create: (data: Partial<ShortNumber>) => fetchProtected(`/admin/main/shortnumbermodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<ShortNumber>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<ShortNumber>) => fetchProtected(`/admin/main/shortnumbermodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<ShortNumber>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const shortNumbersAPI = {
   list: () => fetchProtected(`/admin/main/shortnumbermodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/shortnumbermodel/${id}/`),
-  create: (data: Partial<ShortNumber>) => fetchProtected(`/admin/main/shortnumbermodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<ShortNumber>) => fetchProtected(`/admin/main/shortnumbermodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<ShortNumber>) =>
+    fetchProtected(`/admin/main/shortnumbermodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<ShortNumber>) =>
+    fetchProtected(`/admin/main/shortnumbermodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/sites.ts
+++ b/lib/api/sites.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type Site = {
   id: string
@@ -6,9 +6,37 @@ export type Site = {
   domain: string
 }
 
+const mockSites: Site[] = [
+  {
+    id: "1",
+    display_name: "Main",
+    domain: "example.com",
+  },
+]
+
+export const sitesAPI = {
+  list: async () => Promise.resolve(mockSites),
+  getById: async (id: string) =>
+    Promise.resolve(mockSites.find((s) => s.id === id) || ({} as Site)),
+  // create: (data: Partial<Site>) => fetchProtected(`/admin/main/sitemodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<Site>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<Site>) => fetchProtected(`/admin/main/sitemodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<Site>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const sitesAPI = {
   list: () => fetchProtected(`/admin/main/sitemodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/sitemodel/${id}/`),
-  create: (data: Partial<Site>) => fetchProtected(`/admin/main/sitemodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<Site>) => fetchProtected(`/admin/main/sitemodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<Site>) =>
+    fetchProtected(`/admin/main/sitemodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<Site>) =>
+    fetchProtected(`/admin/main/sitemodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/spams.ts
+++ b/lib/api/spams.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type Spam = {
   id: string
@@ -8,9 +8,39 @@ export type Spam = {
   status: string
 }
 
+const mockSpams: Spam[] = [
+  {
+    id: "1",
+    content: "spam message",
+    source: "user",
+    detected_at: "2024-01-01",
+    status: "new",
+  },
+]
+
+export const spamsAPI = {
+  list: async () => Promise.resolve(mockSpams),
+  getById: async (id: string) =>
+    Promise.resolve(mockSpams.find((s) => s.id === id) || ({} as Spam)),
+  // create: (data: Partial<Spam>) => fetchProtected(`/admin/main/spammodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<Spam>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<Spam>) => fetchProtected(`/admin/main/spammodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<Spam>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const spamsAPI = {
   list: () => fetchProtected(`/admin/main/spammodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/spammodel/${id}/`),
-  create: (data: Partial<Spam>) => fetchProtected(`/admin/main/spammodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<Spam>) => fetchProtected(`/admin/main/spammodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<Spam>) =>
+    fetchProtected(`/admin/main/spammodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<Spam>) =>
+    fetchProtected(`/admin/main/spammodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/submit-sm-response.ts
+++ b/lib/api/submit-sm-response.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type SubmitSmResponse = {
   id: string
@@ -9,9 +9,42 @@ export type SubmitSmResponse = {
   created_at: string
 }
 
+const mockSubmitSmResponses: SubmitSmResponse[] = [
+  {
+    id: "1",
+    queue_message_id: "q1",
+    smpp_message_id: "s1",
+    command_status: "0",
+    sequence_number: "1",
+    created_at: "2024-01-01",
+  },
+]
+
+export const submitSmResponseAPI = {
+  list: async () => Promise.resolve(mockSubmitSmResponses),
+  getById: async (id: string) =>
+    Promise.resolve(
+      mockSubmitSmResponses.find((r) => r.id === id) || ({} as SubmitSmResponse)
+    ),
+  // create: (data: Partial<SubmitSmResponse>) => fetchProtected(`/admin/main/submitsmresponsemodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<SubmitSmResponse>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<SubmitSmResponse>) => fetchProtected(`/admin/main/submitsmresponsemodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<SubmitSmResponse>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const submitSmResponseAPI = {
   list: () => fetchProtected(`/admin/main/submitsmresponsemodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/submitsmresponsemodel/${id}/`),
-  create: (data: Partial<SubmitSmResponse>) => fetchProtected(`/admin/main/submitsmresponsemodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<SubmitSmResponse>) => fetchProtected(`/admin/main/submitsmresponsemodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<SubmitSmResponse>) =>
+    fetchProtected(`/admin/main/submitsmresponsemodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<SubmitSmResponse>) =>
+    fetchProtected(`/admin/main/submitsmresponsemodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/

--- a/lib/api/submit-sm.ts
+++ b/lib/api/submit-sm.ts
@@ -1,4 +1,4 @@
-import { fetchProtected } from "@/lib/utils"
+// import { fetchProtected } from "@/lib/utils"
 
 export type SubmitSm = {
   id: string
@@ -10,9 +10,41 @@ export type SubmitSm = {
   created_at: string
 }
 
+const mockSubmitSms: SubmitSm[] = [
+  {
+    id: "1",
+    queue_message_id: "q1",
+    source_address: "1000",
+    destination_address: "2000",
+    short_message: "Hi",
+    sequence_number: "1",
+    created_at: "2024-01-01",
+  },
+]
+
+export const submitSmAPI = {
+  list: async () => Promise.resolve(mockSubmitSms),
+  getById: async (id: string) =>
+    Promise.resolve(mockSubmitSms.find((s) => s.id === id) || ({} as SubmitSm)),
+  // create: (data: Partial<SubmitSm>) => fetchProtected(`/admin/main/submitsmmodel/`, { method: "POST", body: JSON.stringify(data) }),
+  create: async (_data: Partial<SubmitSm>) => Promise.resolve({ status: 200 }),
+  // update: (id: string, data: Partial<SubmitSm>) => fetchProtected(`/admin/main/submitsmmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  update: async (_id: string, _data: Partial<SubmitSm>) => Promise.resolve({ status: 200 }),
+}
+
+/*
 export const submitSmAPI = {
   list: () => fetchProtected(`/admin/main/submitsmmodel/`),
   getById: (id: string) => fetchProtected(`/admin/main/submitsmmodel/${id}/`),
-  create: (data: Partial<SubmitSm>) => fetchProtected(`/admin/main/submitsmmodel/`, { method: "POST", body: JSON.stringify(data) }),
-  update: (id: string, data: Partial<SubmitSm>) => fetchProtected(`/admin/main/submitsmmodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
+  create: (data: Partial<SubmitSm>) =>
+    fetchProtected(`/admin/main/submitsmmodel/`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  update: (id: string, data: Partial<SubmitSm>) =>
+    fetchProtected(`/admin/main/submitsmmodel/${id}/`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 }
+*/


### PR DESCRIPTION
## Summary
- mock API responses in `lib/api` modules
- keep original fetch code commented at the bottom of each file

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684ab6678100832ca7a8bd61c3675c2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - All API endpoints now use mock data, allowing the application to function without connecting to a live backend.
  - Users can view, create, update, and delete records in various sections using pre-populated mock information.

- **Chores**
  - Switched all API interactions to use local mock data for testing and development purposes. No real network requests are performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->