### PR TITLE
Fix sidebar hover and TypeScript errors

### DIFF
--- a/app/(protected)/alphanames/page.tsx
+++ b/app/(protected)/alphanames/page.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "@/components/common/page-header"
 import { useEffect, useState } from "react"
 import { fetchProtected } from "@/lib/utils"
 import { alphanamesAPI } from "@/lib/api/alphanames"
+import type { Alphaname } from "@/lib/api/alphanames"
 
 
 // const alphaData = [
@@ -113,20 +114,21 @@ const filters = {
 
 export default function AlphaNamesPage() {
   const router = useRouter()
-  const [alphaData, setAlphaData] = useState([])
+  const [alphaData, setAlphaData] = useState<Alphaname[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     setLoading(true)
     setError(null)
-    alphanamesAPI.list()
-      .then(data => setAlphaData(data))
+    alphanamesAPI
+      .list()
+      .then((res) => setAlphaData(res.data))
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
   }, [])
 
-  const handleRowClick = (item: any) => {
+  const handleRowClick = (item: Alphaname) => {
     router.push(`/alphanames/${item.id}`)
   }
 

--- a/app/(protected)/partners-statistics/[id]/page.tsx
+++ b/app/(protected)/partners-statistics/[id]/page.tsx
@@ -34,7 +34,7 @@ export default function PartnerStatisticsDetailPage() {
     }
     partnersStatisticsAPI
       .getById(params.id as string)
-      .then((data) => setItem(data))
+      .then((res) => setItem(res.data))
       .catch(() => setError("Failed to load statistics"))
       .finally(() => setLoading(false))
   }, [params.id])

--- a/app/(protected)/partners/[id]/page.tsx
+++ b/app/(protected)/partners/[id]/page.tsx
@@ -45,7 +45,7 @@ export default function PartnerDetailPage() {
     }
     partnersAPI
       .getById(params.id as string)
-      .then((data) => setItem(data))
+      .then((res) => setItem(res.data))
       .catch(() => setError("Failed to load partner"))
       .finally(() => setLoading(false))
   }, [params.id])

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -304,7 +304,7 @@ const SidebarRail = React.forwardRef<
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
 
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:bg-gray-100 dark:hover:bg-gray-800",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:bg-gray-200 dark:hover:bg-gray-200",
 
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
@@ -463,7 +463,7 @@ const SidebarGroupAction = React.forwardRef<
       data-sidebar="group-action"
       className={cn(
 
-        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-200 dark:hover:text-gray-900 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
 
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 after:md:hidden",
@@ -517,16 +517,16 @@ SidebarMenuItem.displayName = "SidebarMenuItem"
 
 const sidebarMenuButtonVariants = cva(
 
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:dark:hover:bg-sidebar-accent data-[state=open]:dark:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-200 dark:hover:text-gray-900 focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:dark:hover:bg-gray-200 data-[state=open]:dark:hover:text-gray-900 group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
 
   {
     variants: {
       variant: {
         default:
 
-          "hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground",
+          "hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-200 dark:hover:text-gray-900",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-200 dark:hover:text-gray-900 hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
 
       },
       size: {
@@ -616,7 +616,7 @@ const SidebarMenuAction = React.forwardRef<
       data-sidebar="menu-action"
       className={cn(
 
-        "absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-200 dark:hover:text-gray-900 focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
 
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 after:md:hidden",
@@ -734,7 +734,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-active={isActive}
       className={cn(
 
-        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-sidebar-accent dark:hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-200 dark:hover:text-gray-900 focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
 
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
         size === "sm" && "text-xs",

--- a/lib/api/alphanames.ts
+++ b/lib/api/alphanames.ts
@@ -4,6 +4,21 @@
 // const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://your.external.api/v1"
 
 // import { fetchProtected } from "@/lib/utils"
+import type { ApiResponse, PaginatedResponse } from "@/types"
+
+export type Alphaname = {
+  id: string
+  alpha_name: string
+  ctn: string
+  system_id: string
+  active: boolean
+  bind_mode: string
+  alias: string
+  ip_address: string
+  description: string
+  created_at?: string
+  updated_at?: string
+}
 
 const mockAlphanames: Alphaname[] = [
   {
@@ -22,24 +37,46 @@ const mockAlphanames: Alphaname[] = [
 ]
 
 export const alphanamesAPI = {
-  getById: async (id: string) =>
-    Promise.resolve(
-      mockAlphanames.find((a) => a.id === id) || ({} as Alphaname)
-    ),
-  // create: (data: any) =>
-  //   fetchProtected(`/admin/main/alphanamemodel/`, {
-  //     method: "POST",
-  //     body: JSON.stringify(data),
-  //   }),
-  create: async (_data: any) => Promise.resolve({ status: 200 }),
-  // update: (id: string, data: any) =>
-  //   fetchProtected(`/admin/main/alphanamemodel/${id}/`, {
-  //     method: "PUT",
-  //     body: JSON.stringify(data),
-  //   }),
-  update: async (_id: string, _data: any) => Promise.resolve({ status: 200 }),
-  list: async () => Promise.resolve(mockAlphanames),
-  // ... другие методы
+  async getById(id: string): Promise<ApiResponse<Alphaname>> {
+    const item = mockAlphanames.find((a) => a.id === id)
+    if (!item) {
+      return { data: null as any, success: false, message: "Item not found" }
+    }
+    return { data: item, success: true }
+  },
+  create: async (data: Alphaname): Promise<ApiResponse<Alphaname>> => {
+    const newItem: Alphaname = {
+      ...data,
+      id: Math.random().toString(36).slice(2),
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    mockAlphanames.push(newItem)
+    return { data: newItem, success: true }
+  },
+  update: async (id: string, updates: Partial<Alphaname>): Promise<ApiResponse<Alphaname>> => {
+    const index = mockAlphanames.findIndex((a) => a.id === id)
+    if (index === -1) {
+      return { data: null as any, success: false, message: "Item not found" }
+    }
+    mockAlphanames[index] = { ...mockAlphanames[index], ...updates, updated_at: new Date().toISOString() }
+    return { data: mockAlphanames[index], success: true }
+  },
+  list: async (): Promise<PaginatedResponse<Alphaname>> => {
+    return {
+      data: mockAlphanames,
+      total: mockAlphanames.length,
+      page: 1,
+      limit: mockAlphanames.length,
+      totalPages: 1,
+    }
+  },
+  getAlphaNamesList: async (): Promise<ApiResponse<string[]>> => {
+    return { data: mockAlphanames.map((a) => a.alpha_name), success: true }
+  },
+  getCtnList: async (): Promise<ApiResponse<string[]>> => {
+    return { data: mockAlphanames.map((a) => a.ctn), success: true }
+  },
 }
 
 /*
@@ -58,21 +95,6 @@ export const alphanamesAPI = {
   list: () => fetchProtected(`/admin/main/alphanamemodel/`),
 }
 */
-
-// Типизация (можно вынести отдельно)
-export type Alphaname = {
-  id: string
-  alpha_name: string
-  ctn: string
-  system_id: string
-  active: boolean
-  bind_mode: string
-  alias: string
-  ip_address: string
-  description: string
-  created_at?: string
-  updated_at?: string
-}
 
 // Базовый хелпер (опционально, можно добавить обработку токенов)
 async function request<T>(url: string, options?: RequestInit): Promise<T> {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -62,7 +62,7 @@ class MockAPI<T extends { id: string }> {
       id: Math.random().toString(36).substr(2, 9),
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
-    } as T
+    } as unknown as T
 
     this.data.push(newItem)
 

--- a/lib/api/partners-statistics.ts
+++ b/lib/api/partners-statistics.ts
@@ -18,12 +18,23 @@ const mockPartnerStats: PartnerStatistics[] = [
   },
 ]
 
+import type { ApiResponse, PaginatedResponse } from "@/types"
+
 export const partnersStatisticsAPI = {
-  list: async () => Promise.resolve(mockPartnerStats),
-  getById: async (id: string) =>
-    Promise.resolve(
-      mockPartnerStats.find((p) => p.id === id) || ({} as PartnerStatistics)
-    ),
+  list: async (): Promise<PaginatedResponse<PartnerStatistics>> =>
+    Promise.resolve({
+      data: mockPartnerStats,
+      total: mockPartnerStats.length,
+      page: 1,
+      limit: mockPartnerStats.length,
+      totalPages: 1,
+    }),
+  getById: async (id: string): Promise<ApiResponse<PartnerStatistics>> => {
+    const item = mockPartnerStats.find((p) => p.id === id)
+    return item
+      ? { data: item, success: true }
+      : { data: null as any, success: false, message: "Item not found" }
+  },
   create: async (_data: Partial<PartnerStatistics>) =>
     Promise.resolve({ status: 200 }),
   update: async (_id: string, _data: Partial<PartnerStatistics>) =>

--- a/lib/api/partners.ts
+++ b/lib/api/partners.ts
@@ -1,4 +1,5 @@
 // import { fetchProtected } from "@/lib/utils"
+import type { ApiResponse, PaginatedResponse } from "@/types"
 
 export type Partner = {
   id: string
@@ -29,9 +30,20 @@ const mockPartners: Partner[] = [
 ]
 
 export const partnersAPI = {
-  list: async () => Promise.resolve(mockPartners),
-  getById: async (id: string) =>
-    Promise.resolve(mockPartners.find((p) => p.id === id) || ({} as Partner)),
+  list: async (): Promise<PaginatedResponse<Partner>> =>
+    Promise.resolve({
+      data: mockPartners,
+      total: mockPartners.length,
+      page: 1,
+      limit: mockPartners.length,
+      totalPages: 1,
+    }),
+  getById: async (id: string): Promise<ApiResponse<Partner>> => {
+    const item = mockPartners.find((p) => p.id === id)
+    return item
+      ? { data: item, success: true }
+      : { data: null as any, success: false, message: "Item not found" }
+  },
   create: async (_data: Partial<Partner>) => Promise.resolve({ status: 200 }),
   update: async (_id: string, _data: Partial<Partner>) =>
     Promise.resolve({ status: 200 }),


### PR DESCRIPTION
## Summary
- update sidebar hover styles for consistent gray tone
- adjust nav pages to use typed API responses
- standardize API mocks and generics
- tweak MockAPI generics for TS

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684c0cce4918832c986ac5a995e2d607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when displaying partner and partner statistics details.

- **Refactor**
  - Enhanced type safety and consistency in API responses for alphanames, partners, and partner statistics.
  - Improved state and event handling in the AlphaNames page for better data accuracy.

- **Style**
  - Updated sidebar hover colors for a more consistent look in light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->