### PR TITLE
Fix duplicate react imports and format

### DIFF
--- a/app/(protected)/category-mt/page.tsx
+++ b/app/(protected)/category-mt/page.tsx
@@ -1,23 +1,26 @@
-"use client"
+"use client";
 
-import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
-import { Plus } from "lucide-react"
-import { DataTable } from "@/components/common/data-table"
-import { PageHeader } from "@/components/common/page-header"
-import type { CategoryMT } from "@/lib/api/category-mt"
-import { categoryMTAPI } from "@/lib/api/category-mt"
-import type { CategoryStatistic } from "@/lib/api/category-statistics"
-import { categoryStatisticsAPI } from "@/lib/api/category-statistics"
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useMemo } from "react";
+import { Plus } from "lucide-react";
+import { DataTable } from "@/components/common/data-table";
+import { PageHeader } from "@/components/common/page-header";
+import type { CategoryMT } from "@/lib/api/category-mt";
+import { categoryMTAPI } from "@/lib/api/category-mt";
+import type { CategoryStatistic } from "@/lib/api/category-statistics";
+import { categoryStatisticsAPI } from "@/lib/api/category-statistics";
 import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
+  PieChart,
+  Pie,
+  Cell,
   Tooltip,
   Legend,
   ResponsiveContainer,
-} from "recharts"
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 
 // Данные теперь загружаются через API
 
@@ -27,19 +30,19 @@ const columns = [
   { key: "ip_address", label: "IP Address" },
   { key: "cdr", label: "Cdr" },
   { key: "sms_type_number", label: "SMS type number" },
-  { 
-    key: "created", 
+  {
+    key: "created",
     label: "Created",
-    render: (value: string) => value ? value.replace(/,\d+$/, "") : ""
+    render: (value: string) => (value ? value.replace(/,\d+$/, "") : ""),
   },
-  { 
-    key: "modified", 
+  {
+    key: "modified",
     label: "Modified",
-    render: (value: string) => value ? value.replace(/,\d+$/, "") : ""
+    render: (value: string) => (value ? value.replace(/,\d+$/, "") : ""),
   },
   { key: "created_by", label: "Created By" },
   { key: "updated_by", label: "Updated By" },
-]
+];
 
 // Фильтры (по имени категории)
 const filters = {
@@ -50,8 +53,8 @@ const filters = {
     "Service",
     "Transaction",
     "Transactions",
-  ]
-}
+  ],
+};
 
 // Columns and filters for category statistics table
 const statsColumns = [
@@ -61,7 +64,7 @@ const statsColumns = [
   { key: "pattern_stats", label: "Pattern Stats" },
   { key: "source_types", label: "Source Types" },
   { key: "last_updated", label: "Last Updated" },
-]
+];
 
 const statsFilters = {
   name: [
@@ -73,53 +76,81 @@ const statsFilters = {
     "Transaction",
     "Transactions",
   ],
-}
+};
 
 export default function CategoryMTPage() {
-  const router = useRouter()
-  const [data, setData] = useState<CategoryMT[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [stats, setStats] = useState<CategoryStatistic[]>([])
-  const [statsLoading, setStatsLoading] = useState(true)
-  const [statsError, setStatsError] = useState<string | null>(null)
+  const router = useRouter();
+  const [data, setData] = useState<CategoryMT[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<CategoryStatistic[]>([]);
+  const [statsLoading, setStatsLoading] = useState(true);
+  const [statsError, setStatsError] = useState<string | null>(null);
 
-  const chartData = stats.map((s) => ({
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  const filteredStats = useMemo(() => {
+    return stats.filter((s) => {
+      const date = s.last_updated.split(" ")[0];
+      if (dateFrom && date < dateFrom) return false;
+      if (dateTo && date > dateTo) return false;
+      return true;
+    });
+  }, [stats, dateFrom, dateTo]);
+
+  const messagesByCategory = filteredStats.map((s) => ({
     name: s.name,
-    total: parseInt(s.message_types.match(/Total:\s*(\d+)/)?.[1] || "0"),
-    alphaname: parseInt(s.source_types.match(/Alphaname:\s*(\d+)/)?.[1] || "0"),
-    shortNumber: parseInt(s.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0"),
-  }))
+    value: parseInt(s.message_types.match(/Total:\s*(\d+)/)?.[1] || "0"),
+  }));
+
+  const sourceTypesTotals = filteredStats.reduce(
+    (acc, s) => {
+      acc.alphaname += parseInt(
+        s.source_types.match(/Alphaname:\s*(\d+)/)?.[1] || "0",
+      );
+      acc.shortNumber += parseInt(
+        s.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0",
+      );
+      return acc;
+    },
+    { alphaname: 0, shortNumber: 0 },
+  );
+
+  const sourceTypesData = [
+    { name: "Alphaname", value: sourceTypesTotals.alphaname },
+    { name: "Short Number", value: sourceTypesTotals.shortNumber },
+  ];
 
   useEffect(() => {
-    setLoading(true)
+    setLoading(true);
     categoryMTAPI
       .list()
       .then((list) => setData(list))
       .catch(() => setError("Failed to load categories"))
-      .finally(() => setLoading(false))
-  }, [])
+      .finally(() => setLoading(false));
+  }, []);
 
   useEffect(() => {
-    setStatsLoading(true)
+    setStatsLoading(true);
     categoryStatisticsAPI
       .list()
       .then((list) => setStats(list))
       .catch(() => setStatsError("Failed to load statistics"))
-      .finally(() => setStatsLoading(false))
-  }, [])
+      .finally(() => setStatsLoading(false));
+  }, []);
 
   const handleRowClick = (item: CategoryMT) => {
-    router.push(`/category-mt/${item.id}`)
-  }
+    router.push(`/category-mt/${item.id}`);
+  };
 
   const handleStatsRowClick = (item: CategoryStatistic) => {
-    router.push(`/category-statistics/${item.id}`)
-  }
+    router.push(`/category-statistics/${item.id}`);
+  };
 
   const handleAdd = () => {
-    router.push("/category-mt/new")
-  }
+    router.push("/category-mt/new");
+  };
 
   return (
     <div className="space-y-6">
@@ -134,44 +165,98 @@ export default function CategoryMTPage() {
       />
 
       <div className="space-y-4">
-        <h2 className="text-xl font-bold">Category Statistics</h2>
-        <DataTable
-          columns={statsColumns}
-          data={stats}
-          isLoading={statsLoading}
-          onRowClick={handleStatsRowClick}
-          searchPlaceholder="Search statistics..."
-          filters={statsFilters}
-        />
-        {statsError && <div className="text-red-600">{statsError}</div>}
-
-        {/* Charts */}
-        <div className="grid gap-6 md:grid-cols-2">
-          <div className="rounded-lg border bg-card p-4">
-            <h3 className="mb-2 text-lg font-bold">Messages by Category</h3>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={chartData}>
-                <XAxis dataKey="name" />
-                <YAxis />
-                <Tooltip />
-                <Bar dataKey="total" fill="#8884d8" name="Total" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <h3 className="mb-2 text-lg font-bold">Source Types</h3>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={chartData}>
-                <XAxis dataKey="name" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="alphaname" stackId="a" fill="#82ca9d" name="Alphaname" />
-                <Bar dataKey="shortNumber" stackId="a" fill="#8884d8" name="Short Number" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Category Statistics</CardTitle>
+            <div className="mt-4 flex flex-wrap items-end gap-4">
+              <div className="flex items-center gap-2">
+                <Label htmlFor="date-from">From</Label>
+                <Input
+                  id="date-from"
+                  type="date"
+                  value={dateFrom}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  className="max-w-[160px]"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="date-to">To</Label>
+                <Input
+                  id="date-to"
+                  type="date"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  className="max-w-[160px]"
+                />
+              </div>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setDateFrom("");
+                  setDateTo("");
+                }}
+              >
+                Reset
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <DataTable
+              columns={statsColumns}
+              data={filteredStats}
+              isLoading={statsLoading}
+              onRowClick={handleStatsRowClick}
+              searchPlaceholder="Search statistics..."
+              filters={statsFilters}
+            />
+            {statsError && <div className="text-red-600">{statsError}</div>}
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="rounded-lg border bg-card p-4">
+                <h3 className="mb-2 text-lg font-bold">Messages by Category</h3>
+                <ResponsiveContainer width="100%" height={200}>
+                  <PieChart>
+                    <Pie
+                      data={messagesByCategory}
+                      dataKey="value"
+                      nameKey="name"
+                      outerRadius={80}
+                    >
+                      {messagesByCategory.map((entry, index) => (
+                        <Cell
+                          key={`mc-${index}`}
+                          fill={index % 2 === 0 ? "#8884d8" : "#82ca9d"}
+                        />
+                      ))}
+                    </Pie>
+                    <Tooltip />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="rounded-lg border bg-card p-4">
+                <h3 className="mb-2 text-lg font-bold">Source Types</h3>
+                <ResponsiveContainer width="100%" height={200}>
+                  <PieChart>
+                    <Pie
+                      data={sourceTypesData}
+                      dataKey="value"
+                      nameKey="name"
+                      outerRadius={80}
+                    >
+                      {sourceTypesData.map((entry, index) => (
+                        <Cell
+                          key={`st-${index}`}
+                          fill={index === 0 ? "#82ca9d" : "#8884d8"}
+                        />
+                      ))}
+                    </Pie>
+                    <Tooltip />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       <DataTable
@@ -184,5 +269,5 @@ export default function CategoryMTPage() {
       />
       {error && <div className="text-red-600">{error}</div>}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- format Category MT page with Prettier and ensure only one React import
- keep date filter and pie charts functionality

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684fa24edf94832c80919ccfcf92b9e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added date range filtering to category statistics, allowing users to filter data by last updated date.
- **Refactor**
  - Replaced bar charts with pie charts for a clearer visualization of messages by category and source type.
  - Updated chart appearance with reduced height and improved color-coding, tooltips, and legends.
- **Style**
  - Enhanced UI with a card layout, date input fields, and a reset filter button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->