### PR TITLE
Add detailed charts to Category MT page

### DIFF
--- a/components/common/statistics-panel.tsx
+++ b/components/common/statistics-panel.tsx
@@ -19,8 +19,7 @@ import {
   YAxis,
   CartesianGrid,
   Line,
-  Area,
-  AreaChart,
+  LineChart,
 } from "recharts"
 
 interface CategoryStatistic {
@@ -105,14 +104,14 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
     }, 0)
 
     const totalPatterns = filteredData.reduce((sum, item) => {
-      const active = Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0")
-      const inactive = Number.parseInt(item.pattern_stats.match(/Inactive:\s*(\d+)/)?.[1] || "0")
-      return sum + active + inactive
+      const matched = Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0")
+      const auto = Number.parseInt(item.pattern_stats.match(/Auto Categorized:\s*(\d+)/)?.[1] || "0")
+      return sum + matched + auto
     }, 0)
 
     const activePatterns = filteredData.reduce((sum, item) => {
-      const active = Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0")
-      return sum + active
+      const matched = Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0")
+      return sum + matched
     }, 0)
 
     const totalSources = filteredData.reduce((sum, item) => {
@@ -139,6 +138,15 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
     color: COLORS[index % COLORS.length],
   }))
 
+  const messageTypeData = filteredData.map((item) => ({
+    name: item.name,
+    id: item.id,
+    sar: Number.parseInt(item.message_types.match(/SAR:\s*(\d+)/)?.[1] || "0"),
+    udh: Number.parseInt(item.message_types.match(/UDH:\s*(\d+)/)?.[1] || "0"),
+    payload: Number.parseInt(item.message_types.match(/Payload:\s*(\d+)/)?.[1] || "0"),
+    simple: Number.parseInt(item.message_types.match(/Simple:\s*(\d+)/)?.[1] || "0"),
+  }))
+
   const sourceTypesData = filteredData.map((item, index) => ({
     name: item.name,
     id: item.id,
@@ -146,26 +154,35 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
     shortNumber: Number.parseInt(item.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0"),
   }))
 
-  const patternStatusData = filteredData.map((item, index) => ({
+  const patternStatusData = filteredData.map((item) => ({
     name: item.name,
     id: item.id,
-    active: Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0"),
-    inactive: Number.parseInt(item.pattern_stats.match(/Inactive:\s*(\d+)/)?.[1] || "0"),
+    matched: Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0"),
+    auto: Number.parseInt(item.pattern_stats.match(/Auto Categorized:\s*(\d+)/)?.[1] || "0"),
   }))
 
-  const trendData = filteredData.map((item, index) => {
-    const total = Number.parseInt(item.message_types.match(/Total:\s*(\d+)/)?.[1] || "0")
-    return {
-      name: item.name,
-      id: item.id,
-      messages: total,
-      efficiency:
-        (Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0") /
-          (Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0") +
-            Number.parseInt(item.pattern_stats.match(/Inactive:\s*(\d+)/)?.[1] || "1"))) *
-        100,
-    }
-  })
+  const trendData = useMemo(() => {
+    const grouped: Record<string, { date: string; messages: number; patterns: number; sources: number }> = {}
+
+    filteredData.forEach((item) => {
+      const date = item.last_updated.split(" ")[0]
+      const messages = Number.parseInt(item.message_types.match(/Total:\s*(\d+)/)?.[1] || "0")
+      const patterns = Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0")
+      const sources =
+        Number.parseInt(item.source_types.match(/Alphaname:\s*(\d+)/)?.[1] || "0") +
+        Number.parseInt(item.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0")
+
+      if (!grouped[date]) {
+        grouped[date] = { date, messages: 0, patterns: 0, sources: 0 }
+      }
+
+      grouped[date].messages += messages
+      grouped[date].patterns += patterns
+      grouped[date].sources += sources
+    })
+
+    return Object.values(grouped).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+  }, [filteredData])
 
   const handleChartClick = (data: any) => {
     if (data && data.id && onCategoryClick) {
@@ -296,8 +313,9 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
       <Tabs defaultValue="overview" className="space-y-4">
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="sources">Sources</TabsTrigger>
-          <TabsTrigger value="patterns">Patterns</TabsTrigger>
+          <TabsTrigger value="message-types">Message Types</TabsTrigger>
+          <TabsTrigger value="pattern-stats">Pattern Stats</TabsTrigger>
+          <TabsTrigger value="source-types">Source Types</TabsTrigger>
           <TabsTrigger value="trends">Trends</TabsTrigger>
         </TabsList>
 
@@ -351,7 +369,51 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
           </div>
         </TabsContent>
 
-        <TabsContent value="sources" className="space-y-4">
+        <TabsContent value="message-types" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Message Type Breakdown</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={400}>
+                <BarChart data={messageTypeData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="sar" stackId="a" fill="#8884d8" name="SAR" />
+                  <Bar dataKey="udh" stackId="a" fill="#82ca9d" name="UDH" />
+                  <Bar dataKey="payload" stackId="a" fill="#ffc658" name="Payload" />
+                  <Bar dataKey="simple" stackId="a" fill="#ff7300" name="Simple" />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="pattern-stats" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Pattern Stats</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={400}>
+                <BarChart data={patternStatusData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="matched" fill="#22c55e" name="Pattern Matched" />
+                  <Bar dataKey="auto" fill="#8884d8" name="Auto Categorized" />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="source-types" className="space-y-4">
           <Card>
             <CardHeader>
               <CardTitle className="text-lg">Source Types Distribution</CardTitle>
@@ -372,52 +434,23 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
           </Card>
         </TabsContent>
 
-        <TabsContent value="patterns" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Pattern Status</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ResponsiveContainer width="100%" height={400}>
-                <BarChart data={patternStatusData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="active" fill="#22c55e" name="Active" />
-                  <Bar dataKey="inactive" fill="#ef4444" name="Inactive" />
-                </BarChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
         <TabsContent value="trends" className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Performance Trends</CardTitle>
+              <CardTitle className="text-lg">Trends</CardTitle>
             </CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={400}>
-                <AreaChart data={trendData}>
+                <LineChart data={trendData}>
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis yAxisId="left" />
-                  <YAxis yAxisId="right" orientation="right" />
+                  <XAxis dataKey="date" />
+                  <YAxis />
                   <Tooltip />
                   <Legend />
-                  <Area
-                    yAxisId="left"
-                    type="monotone"
-                    dataKey="messages"
-                    stackId="1"
-                    stroke="#8884d8"
-                    fill="#8884d8"
-                    name="Messages"
-                  />
-                  <Line yAxisId="right" type="monotone" dataKey="efficiency" stroke="#ff7300" name="Efficiency %" />
-                </AreaChart>
+                  <Line type="monotone" dataKey="messages" stroke="#8884d8" name="Messages" />
+                  <Line type="monotone" dataKey="patterns" stroke="#22c55e" name="Pattern Matched" />
+                  <Line type="monotone" dataKey="sources" stroke="#ff7300" name="Sources" />
+                </LineChart>
               </ResponsiveContainer>
             </CardContent>
           </Card>

--- a/lib/api/category-charts.ts
+++ b/lib/api/category-charts.ts
@@ -1,0 +1,112 @@
+import { categoryStatisticsAPI } from "./category-statistics"
+import type { CategoryStatistic } from "./category-statistics"
+
+export interface MessageTypeStat {
+  id: string
+  name: string
+  sar: number
+  udh: number
+  payload: number
+  simple: number
+  total: number
+  last_updated: string
+}
+
+export interface PatternStat {
+  id: string
+  name: string
+  matched: number
+  auto: number
+  last_updated: string
+}
+
+export interface SourceTypeStat {
+  id: string
+  name: string
+  alphaname: number
+  short_number: number
+  last_updated: string
+}
+
+export interface TrendPoint {
+  date: string
+  messages: number
+  patterns: number
+  sources: number
+}
+
+const parseMessageTypes = (item: CategoryStatistic): MessageTypeStat => {
+  return {
+    id: item.id,
+    name: item.name,
+    sar: parseInt(item.message_types.match(/SAR:\s*(\d+)/)?.[1] || "0"),
+    udh: parseInt(item.message_types.match(/UDH:\s*(\d+)/)?.[1] || "0"),
+    payload: parseInt(item.message_types.match(/Payload:\s*(\d+)/)?.[1] || "0"),
+    simple: parseInt(item.message_types.match(/Simple:\s*(\d+)/)?.[1] || "0"),
+    total: parseInt(item.message_types.match(/Total:\s*(\d+)/)?.[1] || "0"),
+    last_updated: item.last_updated,
+  }
+}
+
+const parsePatternStats = (item: CategoryStatistic): PatternStat => {
+  return {
+    id: item.id,
+    name: item.name,
+    matched: parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0"),
+    auto: parseInt(item.pattern_stats.match(/Auto Categorized:\s*(\d+)/)?.[1] || "0"),
+    last_updated: item.last_updated,
+  }
+}
+
+const parseSourceTypes = (item: CategoryStatistic): SourceTypeStat => {
+  return {
+    id: item.id,
+    name: item.name,
+    alphaname: parseInt(item.source_types.match(/Alphaname:\s*(\d+)/)?.[1] || "0"),
+    short_number: parseInt(item.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0"),
+    last_updated: item.last_updated,
+  }
+}
+
+export const messageTypesAPI = {
+  list: async (): Promise<MessageTypeStat[]> => {
+    const list = await categoryStatisticsAPI.list()
+    return list.map(parseMessageTypes)
+  },
+}
+
+export const patternStatsAPI = {
+  list: async (): Promise<PatternStat[]> => {
+    const list = await categoryStatisticsAPI.list()
+    return list.map(parsePatternStats)
+  },
+}
+
+export const sourceTypesAPI = {
+  list: async (): Promise<SourceTypeStat[]> => {
+    const list = await categoryStatisticsAPI.list()
+    return list.map(parseSourceTypes)
+  },
+}
+
+export const trendsAPI = {
+  list: async (): Promise<TrendPoint[]> => {
+    const list = await categoryStatisticsAPI.list()
+    const grouped: Record<string, TrendPoint> = {}
+    list.forEach((item) => {
+      const date = item.last_updated.split(" ")[0]
+      const messages = parseInt(item.message_types.match(/Total:\s*(\d+)/)?.[1] || "0")
+      const patterns = parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0")
+      const sources =
+        parseInt(item.source_types.match(/Alphaname:\s*(\d+)/)?.[1] || "0") +
+        parseInt(item.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0")
+      if (!grouped[date]) {
+        grouped[date] = { date, messages: 0, patterns: 0, sources: 0 }
+      }
+      grouped[date].messages += messages
+      grouped[date].patterns += patterns
+      grouped[date].sources += sources
+    })
+    return Object.values(grouped).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+  },
+}


### PR DESCRIPTION
## Summary
- add message type, pattern stats, and source type charts
- refactor trends tab to show lines for all metrics
- provide mock chart APIs for category statistics

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ff1cd07c4832ca59979e254bf1a35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced detailed breakdowns for message types and source types in the statistics panel, including new visualizations and tabs.
  - Added trend charts displaying daily aggregated data for messages, pattern matches, and sources.

- **Refactor**
  - Updated statistics panel to focus on "Pattern Matched" and "Auto Categorized" counts instead of previous metrics.
  - Reorganized and renamed tabs and charts for improved clarity and data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->