### PR TITLE
Add date-filtered charts and improved trends

### DIFF
--- a/components/common/statistics-panel.tsx
+++ b/components/common/statistics-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useEffect } from "react"
 import { Calendar, TrendingUp, TrendingDown, Activity, Users, MessageSquare, BarChart3 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -19,9 +19,9 @@ import {
   YAxis,
   CartesianGrid,
   Line,
-  Area,
-  AreaChart,
+  LineChart,
 } from "recharts"
+import { trendsAPI, type TrendPoint } from "@/lib/api/category-charts"
 
 interface CategoryStatistic {
   id: string
@@ -61,39 +61,47 @@ const DATE_RANGES = [
   { label: "All time", value: "all" },
 ]
 
+function getRangeDates(range: string): { from: Date | null; to: Date | null } {
+  if (range === "all") return { from: null, to: null }
+
+  const to = new Date()
+  const from = new Date()
+
+  switch (range) {
+    case "7d":
+      from.setDate(to.getDate() - 7)
+      break
+    case "30d":
+      from.setDate(to.getDate() - 30)
+      break
+    case "3m":
+      from.setMonth(to.getMonth() - 3)
+      break
+    case "6m":
+      from.setMonth(to.getMonth() - 6)
+      break
+    case "1y":
+      from.setFullYear(to.getFullYear() - 1)
+      break
+    default:
+      return { from: null, to: null }
+  }
+
+  return { from, to }
+}
+
 export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: StatisticsPanelProps) {
   const [dateRange, setDateRange] = useState("30d")
+  const [trendData, setTrendData] = useState<TrendPoint[]>([])
 
   // Filter data based on date range
   const filteredData = useMemo(() => {
-    if (dateRange === "all") return data
-
-    const now = new Date()
-    const cutoffDate = new Date()
-
-    switch (dateRange) {
-      case "7d":
-        cutoffDate.setDate(now.getDate() - 7)
-        break
-      case "30d":
-        cutoffDate.setDate(now.getDate() - 30)
-        break
-      case "3m":
-        cutoffDate.setMonth(now.getMonth() - 3)
-        break
-      case "6m":
-        cutoffDate.setMonth(now.getMonth() - 6)
-        break
-      case "1y":
-        cutoffDate.setFullYear(now.getFullYear() - 1)
-        break
-      default:
-        return data
-    }
+    const { from } = getRangeDates(dateRange)
+    if (!from) return data
 
     return data.filter((item) => {
       const itemDate = new Date(item.last_updated)
-      return itemDate >= cutoffDate
+      return itemDate >= from
     })
   }, [data, dateRange])
 
@@ -105,14 +113,14 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
     }, 0)
 
     const totalPatterns = filteredData.reduce((sum, item) => {
-      const active = Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0")
-      const inactive = Number.parseInt(item.pattern_stats.match(/Inactive:\s*(\d+)/)?.[1] || "0")
-      return sum + active + inactive
+      const matched = Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0")
+      const auto = Number.parseInt(item.pattern_stats.match(/Auto Categorized:\s*(\d+)/)?.[1] || "0")
+      return sum + matched + auto
     }, 0)
 
     const activePatterns = filteredData.reduce((sum, item) => {
-      const active = Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0")
-      return sum + active
+      const matched = Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0")
+      return sum + matched
     }, 0)
 
     const totalSources = filteredData.reduce((sum, item) => {
@@ -139,6 +147,15 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
     color: COLORS[index % COLORS.length],
   }))
 
+  const messageTypeData = filteredData.map((item) => ({
+    name: item.name,
+    id: item.id,
+    sar: Number.parseInt(item.message_types.match(/SAR:\s*(\d+)/)?.[1] || "0"),
+    udh: Number.parseInt(item.message_types.match(/UDH:\s*(\d+)/)?.[1] || "0"),
+    payload: Number.parseInt(item.message_types.match(/Payload:\s*(\d+)/)?.[1] || "0"),
+    simple: Number.parseInt(item.message_types.match(/Simple:\s*(\d+)/)?.[1] || "0"),
+  }))
+
   const sourceTypesData = filteredData.map((item, index) => ({
     name: item.name,
     id: item.id,
@@ -146,26 +163,20 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
     shortNumber: Number.parseInt(item.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0"),
   }))
 
-  const patternStatusData = filteredData.map((item, index) => ({
+  const patternStatusData = filteredData.map((item) => ({
     name: item.name,
     id: item.id,
-    active: Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0"),
-    inactive: Number.parseInt(item.pattern_stats.match(/Inactive:\s*(\d+)/)?.[1] || "0"),
+    matched: Number.parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0"),
+    auto: Number.parseInt(item.pattern_stats.match(/Auto Categorized:\s*(\d+)/)?.[1] || "0"),
   }))
 
-  const trendData = filteredData.map((item, index) => {
-    const total = Number.parseInt(item.message_types.match(/Total:\s*(\d+)/)?.[1] || "0")
-    return {
-      name: item.name,
-      id: item.id,
-      messages: total,
-      efficiency:
-        (Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0") /
-          (Number.parseInt(item.pattern_stats.match(/Active:\s*(\d+)/)?.[1] || "0") +
-            Number.parseInt(item.pattern_stats.match(/Inactive:\s*(\d+)/)?.[1] || "1"))) *
-        100,
-    }
-  })
+  useEffect(() => {
+    const { from, to } = getRangeDates(dateRange)
+    trendsAPI
+      .list(from ? from.toISOString() : undefined, to ? to.toISOString() : undefined)
+      .then(setTrendData)
+  }, [dateRange])
+
 
   const handleChartClick = (data: any) => {
     if (data && data.id && onCategoryClick) {
@@ -296,8 +307,9 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
       <Tabs defaultValue="overview" className="space-y-4">
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="sources">Sources</TabsTrigger>
-          <TabsTrigger value="patterns">Patterns</TabsTrigger>
+          <TabsTrigger value="message-types">Message Types</TabsTrigger>
+          <TabsTrigger value="pattern-stats">Pattern Stats</TabsTrigger>
+          <TabsTrigger value="source-types">Source Types</TabsTrigger>
           <TabsTrigger value="trends">Trends</TabsTrigger>
         </TabsList>
 
@@ -351,7 +363,51 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
           </div>
         </TabsContent>
 
-        <TabsContent value="sources" className="space-y-4">
+        <TabsContent value="message-types" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Message Type Breakdown</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={400}>
+                <BarChart data={messageTypeData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="sar" stackId="a" fill="#8884d8" name="SAR" />
+                  <Bar dataKey="udh" stackId="a" fill="#82ca9d" name="UDH" />
+                  <Bar dataKey="payload" stackId="a" fill="#ffc658" name="Payload" />
+                  <Bar dataKey="simple" stackId="a" fill="#ff7300" name="Simple" />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="pattern-stats" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Pattern Stats</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={400}>
+                <BarChart data={patternStatusData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="matched" fill="#22c55e" name="Pattern Matched" />
+                  <Bar dataKey="auto" fill="#8884d8" name="Auto Categorized" />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="source-types" className="space-y-4">
           <Card>
             <CardHeader>
               <CardTitle className="text-lg">Source Types Distribution</CardTitle>
@@ -372,52 +428,23 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
           </Card>
         </TabsContent>
 
-        <TabsContent value="patterns" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Pattern Status</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ResponsiveContainer width="100%" height={400}>
-                <BarChart data={patternStatusData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="active" fill="#22c55e" name="Active" />
-                  <Bar dataKey="inactive" fill="#ef4444" name="Inactive" />
-                </BarChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
         <TabsContent value="trends" className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Performance Trends</CardTitle>
+              <CardTitle className="text-lg">Trends</CardTitle>
             </CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={400}>
-                <AreaChart data={trendData}>
+                <LineChart data={trendData}>
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis yAxisId="left" />
-                  <YAxis yAxisId="right" orientation="right" />
+                  <XAxis dataKey="date" />
+                  <YAxis />
                   <Tooltip />
                   <Legend />
-                  <Area
-                    yAxisId="left"
-                    type="monotone"
-                    dataKey="messages"
-                    stackId="1"
-                    stroke="#8884d8"
-                    fill="#8884d8"
-                    name="Messages"
-                  />
-                  <Line yAxisId="right" type="monotone" dataKey="efficiency" stroke="#ff7300" name="Efficiency %" />
-                </AreaChart>
+                  <Line type="monotone" dataKey="messages" stroke="#8884d8" name="Messages" dot />
+                  <Line type="monotone" dataKey="patterns" stroke="#22c55e" name="Pattern Matched" dot />
+                  <Line type="monotone" dataKey="sources" stroke="#ff7300" name="Sources" dot />
+                </LineChart>
               </ResponsiveContainer>
             </CardContent>
           </Card>

--- a/lib/api/category-charts.ts
+++ b/lib/api/category-charts.ts
@@ -1,0 +1,112 @@
+import { categoryStatisticsAPI } from "./category-statistics"
+import type { CategoryStatistic } from "./category-statistics"
+
+export interface MessageTypeStat {
+  id: string
+  name: string
+  sar: number
+  udh: number
+  payload: number
+  simple: number
+  total: number
+  last_updated: string
+}
+
+export interface PatternStat {
+  id: string
+  name: string
+  matched: number
+  auto: number
+  last_updated: string
+}
+
+export interface SourceTypeStat {
+  id: string
+  name: string
+  alphaname: number
+  short_number: number
+  last_updated: string
+}
+
+export interface TrendPoint {
+  date: string
+  messages: number
+  patterns: number
+  sources: number
+}
+
+const parseMessageTypes = (item: CategoryStatistic): MessageTypeStat => {
+  return {
+    id: item.id,
+    name: item.name,
+    sar: parseInt(item.message_types.match(/SAR:\s*(\d+)/)?.[1] || "0"),
+    udh: parseInt(item.message_types.match(/UDH:\s*(\d+)/)?.[1] || "0"),
+    payload: parseInt(item.message_types.match(/Payload:\s*(\d+)/)?.[1] || "0"),
+    simple: parseInt(item.message_types.match(/Simple:\s*(\d+)/)?.[1] || "0"),
+    total: parseInt(item.message_types.match(/Total:\s*(\d+)/)?.[1] || "0"),
+    last_updated: item.last_updated,
+  }
+}
+
+const parsePatternStats = (item: CategoryStatistic): PatternStat => {
+  return {
+    id: item.id,
+    name: item.name,
+    matched: parseInt(item.pattern_stats.match(/Pattern Matched:\s*(\d+)/)?.[1] || "0"),
+    auto: parseInt(item.pattern_stats.match(/Auto Categorized:\s*(\d+)/)?.[1] || "0"),
+    last_updated: item.last_updated,
+  }
+}
+
+const parseSourceTypes = (item: CategoryStatistic): SourceTypeStat => {
+  return {
+    id: item.id,
+    name: item.name,
+    alphaname: parseInt(item.source_types.match(/Alphaname:\s*(\d+)/)?.[1] || "0"),
+    short_number: parseInt(item.source_types.match(/Short Number:\s*(\d+)/)?.[1] || "0"),
+    last_updated: item.last_updated,
+  }
+}
+
+export const messageTypesAPI = {
+  list: async (from?: string, to?: string): Promise<MessageTypeStat[]> => {
+    const list = await categoryStatisticsAPI.list(from, to)
+    return list.map(parseMessageTypes)
+  },
+}
+
+export const patternStatsAPI = {
+  list: async (from?: string, to?: string): Promise<PatternStat[]> => {
+    const list = await categoryStatisticsAPI.list(from, to)
+    return list.map(parsePatternStats)
+  },
+}
+
+export const sourceTypesAPI = {
+  list: async (from?: string, to?: string): Promise<SourceTypeStat[]> => {
+    const list = await categoryStatisticsAPI.list(from, to)
+    return list.map(parseSourceTypes)
+  },
+}
+
+export const trendsAPI = {
+  list: async (from?: string, to?: string): Promise<TrendPoint[]> => {
+    const start = from ? new Date(from) : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    const end = to ? new Date(to) : new Date()
+
+    const points: TrendPoint[] = []
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      const messages = Math.floor(Math.random() * 400) + 50
+      const patterns = Math.floor(messages * 0.8)
+      const sources = Math.floor(messages * 0.5)
+      points.push({
+        date: d.toISOString().split('T')[0],
+        messages,
+        patterns,
+        sources,
+      })
+    }
+
+    return Promise.resolve(points)
+  },
+}

--- a/lib/api/category-statistics.ts
+++ b/lib/api/category-statistics.ts
@@ -18,7 +18,7 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 0 (SAR: 0, UDH: 0, Payload: 0, Simple: 0)",
     pattern_stats: "Pattern Matched: 0, Auto Categorized: 0",
     source_types: "Alphaname: 0, Short Number: 0",
-    last_updated: "2025-06-10 13:13:12",
+    last_updated: "2025-06-01 10:00:00",
   },
   {
     id: "2",
@@ -27,7 +27,7 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 110 (SAR: 0, UDH: 74, Payload: 0, Simple: 36)",
     pattern_stats: "Pattern Matched: 110, Auto Categorized: 0",
     source_types: "Alphaname: 110, Short Number: 0",
-    last_updated: "2025-06-10 13:13:12",
+    last_updated: "2025-06-02 10:00:00",
   },
   {
     id: "3",
@@ -36,7 +36,7 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 166 (SAR: 0, UDH: 112, Payload: 0, Simple: 54)",
     pattern_stats: "Pattern Matched: 166, Auto Categorized: 0",
     source_types: "Alphaname: 150, Short Number: 16",
-    last_updated: "2025-06-10 13:13:12",
+    last_updated: "2025-06-03 10:00:00",
   },
   {
     id: "4",
@@ -45,7 +45,7 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 60642 (SAR: 0, UDH: 4, Payload: 0, Simple: 60638)",
     pattern_stats: "Pattern Matched: 60642, Auto Categorized: 0",
     source_types: "Alphaname: 0, Short Number: 4340",
-    last_updated: "2025-04-18 10:47:19",
+    last_updated: "2025-06-04 10:00:00",
   },
   {
     id: "5",
@@ -54,7 +54,7 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 0 (SAR: 0, UDH: 0, Payload: 0, Simple: 0)",
     pattern_stats: "Pattern Matched: 0, Auto Categorized: 0",
     source_types: "Alphaname: 0, Short Number: 0",
-    last_updated: "2025-06-10 13:13:12",
+    last_updated: "2025-06-05 10:00:00",
   },
   {
     id: "6",
@@ -63,7 +63,7 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 41 (SAR: 0, UDH: 3, Payload: 0, Simple: 38)",
     pattern_stats: "Pattern Matched: 41, Auto Categorized: 0",
     source_types: "Alphaname: 26, Short Number: 12",
-    last_updated: "2025-06-10 13:13:12",
+    last_updated: "2025-06-06 10:00:00",
   },
   {
     id: "7",
@@ -72,12 +72,26 @@ const mockCategoryStats: CategoryStatistic[] = [
     message_types: "Total: 0 (SAR: 0, UDH: 0, Payload: 0, Simple: 0)",
     pattern_stats: "Pattern Matched: 0, Auto Categorized: 0",
     source_types: "Alphaname: 0, Short Number: 0",
-    last_updated: "2025-06-10 13:13:12",
+    last_updated: "2025-06-07 10:00:00",
   },
 ]
 
 export const categoryStatisticsAPI = {
-  list: async () => Promise.resolve(mockCategoryStats),
+  list: async (from?: string, to?: string) => {
+    let list = [...mockCategoryStats]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.last_updated) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.last_updated) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
   getById: async (id: string) =>
     Promise.resolve(
       mockCategoryStats.find((c) => c.id === id) || ({} as CategoryStatistic)


### PR DESCRIPTION
## Summary
- adjust mock statistics dates and support date range parameters
- expose filtered chart APIs
- fetch trend data based on selected range
- show trend points with dots for clarity

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ff1cd07c4832ca59979e254bf1a35