### PR TITLE
Add date filter to Category MT statistics

### DIFF
--- a/app/(protected)/category-mt/page.tsx
+++ b/app/(protected)/category-mt/page.tsx
@@ -6,6 +6,8 @@ import { Plus } from "lucide-react"
 import { DataTable } from "@/components/common/data-table"
 import { PageHeader } from "@/components/common/page-header"
 import { StatisticsPanel } from "@/components/common/statistics-panel"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import type { CategoryMT } from "@/lib/api/category-mt"
 import { categoryMTAPI } from "@/lib/api/category-mt"
 import type { CategoryStatistic } from "@/lib/api/category-statistics"
@@ -45,6 +47,8 @@ export default function CategoryMTPage() {
   const [stats, setStats] = useState<CategoryStatistic[]>([])
   const [statsLoading, setStatsLoading] = useState(true)
   const [statsError, setStatsError] = useState<string | null>(null)
+  const [fromDate, setFromDate] = useState("")
+  const [toDate, setToDate] = useState("")
 
   useEffect(() => {
     setLoading(true)
@@ -58,11 +62,11 @@ export default function CategoryMTPage() {
   useEffect(() => {
     setStatsLoading(true)
     categoryStatisticsAPI
-      .list()
+      .list(fromDate || undefined, toDate || undefined)
       .then((list) => setStats(list))
       .catch(() => setStatsError("Failed to load statistics"))
       .finally(() => setStatsLoading(false))
-  }, [])
+  }, [fromDate, toDate])
 
   const handleRowClick = (item: CategoryMT) => {
     router.push(`/category-mt/${item.id}`)
@@ -87,6 +91,27 @@ export default function CategoryMTPage() {
           icon: Plus,
         }}
       />
+
+      <div className="flex items-end gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="from-date">From</Label>
+          <Input
+            id="from-date"
+            type="date"
+            value={fromDate}
+            onChange={(e) => setFromDate(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="to-date">To</Label>
+          <Input
+            id="to-date"
+            type="date"
+            value={toDate}
+            onChange={(e) => setToDate(e.target.value)}
+          />
+        </div>
+      </div>
 
       <StatisticsPanel data={stats} isLoading={statsLoading} onCategoryClick={handleCategoryClick} />
 


### PR DESCRIPTION
## Summary
- add from and to date inputs to Category MT page
- load statistics according to selected dates

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_684ff8d1aee4832caa3a6658e0bfc425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added date range filtering to category statistics with "From" and "To" date input fields, allowing users to filter data by a selected date range. Statistics update automatically when the date range is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->