### PR TITLE
Fix overlapping pie chart labels

### DIFF
--- a/components/common/statistics-panel.tsx
+++ b/components/common/statistics-panel.tsx
@@ -52,6 +52,7 @@ const COLORS = [
   "#ffff00",
 ]
 
+
 const DATE_RANGES = [
   { label: "Last 7 days", value: "7d" },
   { label: "Last 30 days", value: "30d" },
@@ -322,27 +323,44 @@ export function StatisticsPanel({ data, isLoading = false, onCategoryClick }: St
                 <CardTitle className="text-lg">Messages by Category</CardTitle>
               </CardHeader>
               <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <PieChart>
-                    <Pie
-                      data={messagesByCategory}
-                      dataKey="value"
-                      nameKey="name"
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={100}
-                      label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-                      onClick={handleChartClick}
-                      style={{ cursor: "pointer" }}
-                    >
-                      {messagesByCategory.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                      ))}
-                    </Pie>
-                    <Tooltip formatter={(value) => [value.toLocaleString(), "Messages"]} />
-                    <Legend />
-                  </PieChart>
-                </ResponsiveContainer>
+                <div className="flex items-center justify-center">
+                  <div className="w-64 h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={messagesByCategory}
+                          dataKey="value"
+                          nameKey="name"
+                          cx="50%"
+                          cy="50%"
+                          outerRadius={100}
+                          onClick={handleChartClick}
+                          style={{ cursor: "pointer" }}
+                        >
+                          {messagesByCategory.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                          ))}
+                        </Pie>
+                        <Tooltip formatter={(value) => [value.toLocaleString(), "Messages"]} />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <div className="ml-4 space-y-1 text-sm">
+                    {messagesByCategory.map((entry, index) => {
+                      const total = messagesByCategory.reduce((sum, m) => sum + m.value, 0)
+                      const percent = total > 0 ? ((entry.value / total) * 100).toFixed(0) : "0"
+                      return (
+                        <div key={entry.name} className="flex items-center space-x-2">
+                          <span
+                            className="block w-3 h-3 rounded-sm"
+                            style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                          />
+                          <span>{`${entry.name} (${percent}%)`}</span>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
               </CardContent>
             </Card>
 


### PR DESCRIPTION
## Summary
- render pie chart in a fixed square container and place legend beside it
- compute percentages for legend entries

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684ff9159560832c902d19eac07aada6