### PR TITLE
Add mock SMS report API endpoints

### DIFF
--- a/lib/api/alphaname-sms-reports.ts
+++ b/lib/api/alphaname-sms-reports.ts
@@ -1,0 +1,55 @@
+export type AlphanameSmsReport = {
+  id: string
+  alphaname: string
+  partner: string
+  total: number
+  categories: Record<string, number>
+  statuses: Record<string, number>
+  date: string
+}
+
+const mockAlphanameSmsReports: AlphanameSmsReport[] = [
+  {
+    id: "1",
+    alphaname: "OLYMPIA.UZ",
+    partner: "TelecomUZ",
+    total: 60,
+    categories: { Service: 40, Transaction: 20 },
+    statuses: { delivered: 55, failed: 5 },
+    date: "2024-06-01",
+  },
+  {
+    id: "2",
+    alphaname: "FAAcademy",
+    partner: "BeeLine",
+    total: 45,
+    categories: { Education: 45 },
+    statuses: { delivered: 40, failed: 5 },
+    date: "2024-06-02",
+  },
+]
+
+export const alphanameSmsReportsAPI = {
+  list: async (from?: string, to?: string): Promise<AlphanameSmsReport[]> => {
+    let list = [...mockAlphanameSmsReports]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.date) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.date) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
+  getById: async (id: string): Promise<AlphanameSmsReport | null> =>
+    Promise.resolve(
+      mockAlphanameSmsReports.find((item) => item.id === id) || null
+    ),
+  create: async (_data: Partial<AlphanameSmsReport>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<AlphanameSmsReport>) => Promise.resolve({ status: 200 }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}

--- a/lib/api/category-sms-reports.ts
+++ b/lib/api/category-sms-reports.ts
@@ -1,0 +1,49 @@
+export type CategorySmsReport = {
+  id: string
+  category: string
+  total: number
+  statuses: Record<string, number>
+  date: string
+}
+
+const mockCategorySmsReports: CategorySmsReport[] = [
+  {
+    id: "1",
+    category: "Service",
+    total: 100,
+    statuses: { delivered: 95, failed: 5 },
+    date: "2024-06-01",
+  },
+  {
+    id: "2",
+    category: "Transaction",
+    total: 125,
+    statuses: { delivered: 115, failed: 10 },
+    date: "2024-06-03",
+  },
+]
+
+export const categorySmsReportsAPI = {
+  list: async (from?: string, to?: string): Promise<CategorySmsReport[]> => {
+    let list = [...mockCategorySmsReports]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.date) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.date) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
+  getById: async (id: string): Promise<CategorySmsReport | null> =>
+    Promise.resolve(
+      mockCategorySmsReports.find((item) => item.id === id) || null
+    ),
+  create: async (_data: Partial<CategorySmsReport>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<CategorySmsReport>) => Promise.resolve({ status: 200 }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}

--- a/lib/api/partner-sms-reports.ts
+++ b/lib/api/partner-sms-reports.ts
@@ -1,0 +1,60 @@
+export type PartnerSmsReport = {
+  id: string
+  partner: string
+  total: number
+  categories: Record<string, number>
+  statuses: Record<string, number>
+  date: string
+}
+
+const mockPartnerSmsReports: PartnerSmsReport[] = [
+  {
+    id: "1",
+    partner: "TelecomUZ",
+    total: 120,
+    categories: { Service: 70, Transaction: 50 },
+    statuses: { delivered: 100, failed: 20 },
+    date: "2024-06-01",
+  },
+  {
+    id: "2",
+    partner: "BeeLine",
+    total: 80,
+    categories: { Service: 60, Transaction: 20 },
+    statuses: { delivered: 70, failed: 10 },
+    date: "2024-06-02",
+  },
+  {
+    id: "3",
+    partner: "Ucell",
+    total: 150,
+    categories: { Service: 100, Transaction: 50 },
+    statuses: { delivered: 140, failed: 10 },
+    date: "2024-06-03",
+  },
+]
+
+export const partnerSmsReportsAPI = {
+  list: async (from?: string, to?: string): Promise<PartnerSmsReport[]> => {
+    let list = [...mockPartnerSmsReports]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.date) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.date) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
+  getById: async (id: string): Promise<PartnerSmsReport | null> =>
+    Promise.resolve(
+      mockPartnerSmsReports.find((item) => item.id === id) || null
+    ),
+  create: async (_data: Partial<PartnerSmsReport>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<PartnerSmsReport>) => Promise.resolve({ status: 200 }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}

--- a/lib/api/short-number-sms-reports.ts
+++ b/lib/api/short-number-sms-reports.ts
@@ -1,0 +1,55 @@
+export type ShortNumberSmsReport = {
+  id: string
+  short_number: string
+  partner: string
+  total: number
+  categories: Record<string, number>
+  statuses: Record<string, number>
+  date: string
+}
+
+const mockShortNumberSmsReports: ShortNumberSmsReport[] = [
+  {
+    id: "1",
+    short_number: "9000",
+    partner: "TelecomUZ",
+    total: 30,
+    categories: { Service: 30 },
+    statuses: { delivered: 28, failed: 2 },
+    date: "2024-06-01",
+  },
+  {
+    id: "2",
+    short_number: "7777",
+    partner: "Ucell",
+    total: 75,
+    categories: { Transaction: 75 },
+    statuses: { delivered: 70, failed: 5 },
+    date: "2024-06-03",
+  },
+]
+
+export const shortNumberSmsReportsAPI = {
+  list: async (from?: string, to?: string): Promise<ShortNumberSmsReport[]> => {
+    let list = [...mockShortNumberSmsReports]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.date) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.date) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
+  getById: async (id: string): Promise<ShortNumberSmsReport | null> =>
+    Promise.resolve(
+      mockShortNumberSmsReports.find((item) => item.id === id) || null
+    ),
+  create: async (_data: Partial<ShortNumberSmsReport>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<ShortNumberSmsReport>) => Promise.resolve({ status: 200 }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}

--- a/lib/api/status-sms-reports.ts
+++ b/lib/api/status-sms-reports.ts
@@ -1,0 +1,47 @@
+export type StatusSmsReport = {
+  id: string
+  status: string
+  total: number
+  statuses: Record<string, number>
+  date: string
+}
+
+const mockStatusSmsReports: StatusSmsReport[] = [
+  {
+    id: "1",
+    status: "delivered",
+    total: 210,
+    statuses: { delivered: 210, failed: 0 },
+    date: "2024-06-03",
+  },
+  {
+    id: "2",
+    status: "failed",
+    total: 30,
+    statuses: { delivered: 0, failed: 30 },
+    date: "2024-06-03",
+  },
+]
+
+export const statusSmsReportsAPI = {
+  list: async (from?: string, to?: string): Promise<StatusSmsReport[]> => {
+    let list = [...mockStatusSmsReports]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.date) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.date) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
+  getById: async (id: string): Promise<StatusSmsReport | null> =>
+    Promise.resolve(mockStatusSmsReports.find((item) => item.id === id) || null),
+  create: async (_data: Partial<StatusSmsReport>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<StatusSmsReport>) => Promise.resolve({ status: 200 }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}

--- a/lib/api/template-sms-reports.ts
+++ b/lib/api/template-sms-reports.ts
@@ -1,0 +1,55 @@
+export type TemplateSmsReport = {
+  id: string
+  template: string
+  partner: string
+  total: number
+  categories: Record<string, number>
+  statuses: Record<string, number>
+  date: string
+}
+
+const mockTemplateSmsReports: TemplateSmsReport[] = [
+  {
+    id: "1",
+    template: "welcome_msg",
+    partner: "TelecomUZ",
+    total: 50,
+    categories: { Service: 50 },
+    statuses: { delivered: 48, failed: 2 },
+    date: "2024-06-01",
+  },
+  {
+    id: "2",
+    template: "payment_confirm",
+    partner: "BeeLine",
+    total: 35,
+    categories: { Transaction: 35 },
+    statuses: { delivered: 34, failed: 1 },
+    date: "2024-06-02",
+  },
+]
+
+export const templateSmsReportsAPI = {
+  list: async (from?: string, to?: string): Promise<TemplateSmsReport[]> => {
+    let list = [...mockTemplateSmsReports]
+
+    if (from) {
+      const fromDate = new Date(from)
+      list = list.filter((item) => new Date(item.date) >= fromDate)
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      list = list.filter((item) => new Date(item.date) <= toDate)
+    }
+
+    return Promise.resolve(list)
+  },
+  getById: async (id: string): Promise<TemplateSmsReport | null> =>
+    Promise.resolve(
+      mockTemplateSmsReports.find((item) => item.id === id) || null
+    ),
+  create: async (_data: Partial<TemplateSmsReport>) => Promise.resolve({ status: 200 }),
+  update: async (_id: string, _data: Partial<TemplateSmsReport>) => Promise.resolve({ status: 200 }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
+}


### PR DESCRIPTION
## Summary
- add mock API for SMS reports by partner
- add mock API for SMS reports by alphaname
- add mock API for SMS reports by short number
- add mock API for SMS reports by template
- add mock API for SMS reports by category
- add mock API for SMS reports by status

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6851523ac798832c869aebd29ba738d7