### PR TITLE
Adapt components for dark theme

### DIFF
--- a/components/enhanced-date-picker.tsx
+++ b/components/enhanced-date-picker.tsx
@@ -100,7 +100,7 @@ export function EnhancedDatePicker({ from, to, onDateChange, className }: Enhanc
             variant="outline"
             size="sm"
             onClick={() => handlePresetClick(preset)}
-            className="text-xs bg-white/60 border-gray-200/50 hover:bg-blue-50 hover:border-blue-200 transition-colors"
+            className="text-xs"
           >
             {preset.label}
           </Button>
@@ -109,7 +109,7 @@ export function EnhancedDatePicker({ from, to, onDateChange, className }: Enhanc
           variant="outline"
           size="sm"
           onClick={handleReset}
-          className="text-xs bg-white/60 border-gray-200/50 hover:bg-red-50 hover:border-red-200 transition-colors"
+          className="text-xs"
         >
           <RotateCcw className="w-3 h-3 mr-1" />
           Reset
@@ -120,23 +120,22 @@ export function EnhancedDatePicker({ from, to, onDateChange, className }: Enhanc
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {/* From Date */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium text-gray-700">From Date</Label>
+          <Label className="text-sm font-medium">From Date</Label>
           <div className="flex gap-2">
             <div className="flex-1">
               <Input
                 type="date"
                 value={fromInput}
                 onChange={(e) => handleFromInputChange(e.target.value)}
-                className="bg-white/80 border-gray-200/50 hover:bg-white focus:bg-white transition-colors"
               />
             </div>
             <Popover open={fromOpen} onOpenChange={setFromOpen}>
               <PopoverTrigger asChild>
-                <Button variant="outline" size="icon" className="bg-white/80 border-gray-200/50 hover:bg-white">
-                  <CalendarIcon className="h-4 w-4 text-gray-500" />
+                <Button variant="outline" size="icon">
+                  <CalendarIcon className="h-4 w-4" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-auto p-0 bg-white/95 backdrop-blur-sm shadow-xl" align="start">
+              <PopoverContent className="w-auto p-0" align="start">
                 <Calendar mode="single" selected={from} onSelect={handleFromCalendarSelect} initialFocus />
               </PopoverContent>
             </Popover>
@@ -145,23 +144,22 @@ export function EnhancedDatePicker({ from, to, onDateChange, className }: Enhanc
 
         {/* To Date */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium text-gray-700">To Date</Label>
+          <Label className="text-sm font-medium">To Date</Label>
           <div className="flex gap-2">
             <div className="flex-1">
               <Input
                 type="date"
                 value={toInput}
                 onChange={(e) => handleToInputChange(e.target.value)}
-                className="bg-white/80 border-gray-200/50 hover:bg-white focus:bg-white transition-colors"
               />
             </div>
             <Popover open={toOpen} onOpenChange={setToOpen}>
               <PopoverTrigger asChild>
-                <Button variant="outline" size="icon" className="bg-white/80 border-gray-200/50 hover:bg-white">
-                  <CalendarIcon className="h-4 w-4 text-gray-500" />
+                <Button variant="outline" size="icon">
+                  <CalendarIcon className="h-4 w-4" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-auto p-0 bg-white/95 backdrop-blur-sm shadow-xl" align="start">
+              <PopoverContent className="w-auto p-0" align="start">
                 <Calendar mode="single" selected={to} onSelect={handleToCalendarSelect} initialFocus />
               </PopoverContent>
             </Popover>
@@ -171,8 +169,8 @@ export function EnhancedDatePicker({ from, to, onDateChange, className }: Enhanc
 
       {/* Selected Range Display */}
       {from && to && (
-        <div className="p-3 bg-blue-50/50 border border-blue-200/50 rounded-lg">
-          <div className="flex items-center gap-2 text-sm text-blue-700">
+        <div className="p-3 bg-muted border rounded-lg">
+          <div className="flex items-center gap-2 text-sm">
             <CalendarIcon className="w-4 h-4" />
             <span className="font-medium">Selected Range:</span>
             <span>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -2,29 +2,29 @@ import Link from "next/link"
 
 export function Footer() {
   return (
-    <footer className="bg-gray-900 text-white">
+    <footer className="bg-background text-foreground">
       <div className="container mx-auto px-4 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
             <h3 className="text-xl font-bold mb-4">MyApp</h3>
-            <p className="text-gray-400">Building amazing experiences with modern web technologies.</p>
+            <p className="text-muted-foreground">Building amazing experiences with modern web technologies.</p>
           </div>
 
           <div>
             <h4 className="font-semibold mb-4">Quick Links</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/" className="text-gray-400 hover:text-white transition-colors">
+                <Link href="/" className="text-muted-foreground hover:text-foreground transition-colors">
                   Home
                 </Link>
               </li>
               <li>
-                <Link href="/about" className="text-gray-400 hover:text-white transition-colors">
+                <Link href="/about" className="text-muted-foreground hover:text-foreground transition-colors">
                   About
                 </Link>
               </li>
               <li>
-                <Link href="/services" className="text-gray-400 hover:text-white transition-colors">
+                <Link href="/services" className="text-muted-foreground hover:text-foreground transition-colors">
                   Services
                 </Link>
               </li>
@@ -34,22 +34,22 @@ export function Footer() {
           <div>
             <h4 className="font-semibold mb-4">Services</h4>
             <ul className="space-y-2">
-              <li className="text-gray-400">Web Development</li>
-              <li className="text-gray-400">Mobile Apps</li>
-              <li className="text-gray-400">Consulting</li>
+              <li className="text-muted-foreground">Web Development</li>
+              <li className="text-muted-foreground">Mobile Apps</li>
+              <li className="text-muted-foreground">Consulting</li>
             </ul>
           </div>
 
           <div>
             <h4 className="font-semibold mb-4">Contact</h4>
-            <div className="space-y-2 text-gray-400">
+            <div className="space-y-2 text-muted-foreground">
               <p>hello@myapp.com</p>
               <p>+1 (555) 123-4567</p>
             </div>
           </div>
         </div>
 
-        <div className="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
+        <div className="border-t border-border mt-8 pt-8 text-center text-muted-foreground">
           <p>&copy; 2024 MyApp. All rights reserved.</p>
         </div>
       </div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,6 @@
 export function Header() {
   return (
-    <div className="border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+    <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container mx-auto px-4 py-2">
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground">Welcome to MyApp Dashboard</div>

--- a/components/modern-statistics-card.tsx
+++ b/components/modern-statistics-card.tsx
@@ -59,17 +59,17 @@ export function ModernStatisticsCard({
 
   if (loading) {
     return (
-      <Card className="bg-white/80 backdrop-blur-sm border-gray-200/50 shadow-lg hover:shadow-xl transition-all duration-300">
+      <Card className="bg-card/80 backdrop-blur-sm border border-border shadow-lg hover:shadow-xl transition-all duration-300">
         <CardContent className="p-6">
           <div className="animate-pulse">
             <div className="flex items-start justify-between mb-4">
               <div className="space-y-2">
-                <div className="h-4 bg-gray-200 rounded w-24"></div>
-                <div className="h-8 bg-gray-200 rounded w-32"></div>
+                <div className="h-4 bg-muted rounded w-24"></div>
+                <div className="h-8 bg-muted rounded w-32"></div>
               </div>
-              <div className="w-12 h-12 bg-gray-200 rounded-xl"></div>
+              <div className="w-12 h-12 bg-muted rounded-xl"></div>
             </div>
-            <div className="h-4 bg-gray-200 rounded w-20"></div>
+            <div className="h-4 bg-muted rounded w-20"></div>
           </div>
         </CardContent>
       </Card>
@@ -79,15 +79,15 @@ export function ModernStatisticsCard({
   return (
     <Card
       className={cn(
-        "bg-white/80 backdrop-blur-sm border-gray-200/50 shadow-lg hover:shadow-xl transition-all duration-300 group hover:scale-[1.02]",
+        "bg-card/80 backdrop-blur-sm border border-border shadow-lg hover:shadow-xl transition-all duration-300 group hover:scale-[1.02]",
         colors.bg,
       )}
     >
       <CardContent className="p-6">
         <div className="flex items-start justify-between mb-4">
           <div className="space-y-2">
-            <p className="text-sm font-medium text-gray-600">{title}</p>
-            <p className="text-3xl font-bold text-gray-900 group-hover:text-gray-800 transition-colors">
+            <p className="text-sm font-medium text-muted-foreground">{title}</p>
+            <p className="text-3xl font-bold group-hover:text-foreground transition-colors">
               {typeof value === "number" ? value.toLocaleString() : value}
             </p>
           </div>
@@ -102,7 +102,7 @@ export function ModernStatisticsCard({
         </div>
 
         <div className="flex items-center justify-between">
-          {subtitle && <p className="text-sm text-gray-500 flex-1">{subtitle}</p>}
+          {subtitle && <p className="text-sm text-muted-foreground flex-1">{subtitle}</p>}
           {trendValue && (
             <Badge
               variant="secondary"

--- a/components/refined-charts.tsx
+++ b/components/refined-charts.tsx
@@ -56,8 +56,8 @@ const COLORS = ["#3B82F6", "#10B981", "#F59E0B", "#EF4444", "#8B5CF6", "#06B6D4"
 const CustomTooltip = ({ active, payload, label }: any) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-white/95 backdrop-blur-sm p-3 rounded-lg shadow-lg border border-gray-200/50">
-        <p className="font-medium text-gray-900">{label}</p>
+      <div className="bg-card p-3 rounded-lg shadow-lg border">
+        <p className="font-medium">{label}</p>
         {payload.map((entry: any, index: number) => (
           <p key={index} className="text-sm" style={{ color: entry.color }}>
             {entry.name}: {typeof entry.value === "number" ? entry.value.toLocaleString() : entry.value}
@@ -73,11 +73,11 @@ export function RefinedPieChart({ data, title }: RefinedPieChartProps) {
   if (!data || data.length === 0) {
     return (
       <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
-        <div className="h-80 flex items-center justify-center text-gray-500">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <div className="h-80 flex items-center justify-center text-muted-foreground">
           <div className="text-center">
-            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
-              <div className="w-8 h-8 bg-gray-300 rounded-full"></div>
+            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-full flex items-center justify-center">
+              <div className="w-8 h-8 bg-muted-foreground rounded-full"></div>
             </div>
             <p>No data available</p>
           </div>
@@ -88,7 +88,7 @@ export function RefinedPieChart({ data, title }: RefinedPieChartProps) {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <h3 className="text-lg font-semibold ">{title}</h3>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
@@ -120,11 +120,11 @@ export function RefinedBarChart({ data, title }: RefinedBarChartProps) {
   if (!data || data.length === 0) {
     return (
       <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
-        <div className="h-80 flex items-center justify-center text-gray-500">
+        <h3 className="text-lg font-semibold ">{title}</h3>
+        <div className="h-80 flex items-center justify-center text-muted-foreground">
           <div className="text-center">
-            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-lg flex items-center justify-center">
-              <div className="w-8 h-2 bg-gray-300 rounded"></div>
+            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-lg flex items-center justify-center">
+              <div className="w-8 h-2 bg-muted-foreground rounded"></div>
             </div>
             <p>No data available</p>
           </div>
@@ -135,7 +135,7 @@ export function RefinedBarChart({ data, title }: RefinedBarChartProps) {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <h3 className="text-lg font-semibold ">{title}</h3>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 60 }}>
@@ -169,11 +169,11 @@ export function RefinedLineChart({ data, title }: RefinedLineChartProps) {
   if (!data || data.length === 0) {
     return (
       <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
-        <div className="h-80 flex items-center justify-center text-gray-500">
+        <h3 className="text-lg font-semibold ">{title}</h3>
+        <div className="h-80 flex items-center justify-center text-muted-foreground">
           <div className="text-center">
-            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-lg flex items-center justify-center">
-              <div className="w-8 h-1 bg-gray-300 rounded"></div>
+            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-lg flex items-center justify-center">
+              <div className="w-8 h-1 bg-muted-foreground rounded"></div>
             </div>
             <p>No data available</p>
           </div>
@@ -184,7 +184,7 @@ export function RefinedLineChart({ data, title }: RefinedLineChartProps) {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <h3 className="text-lg font-semibold ">{title}</h3>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
@@ -235,11 +235,11 @@ export function RefinedAreaChart({ data, title }: RefinedAreaChartProps) {
   if (!data || data.length === 0) {
     return (
       <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
-        <div className="h-80 flex items-center justify-center text-gray-500">
+        <h3 className="text-lg font-semibold ">{title}</h3>
+        <div className="h-80 flex items-center justify-center text-muted-foreground">
           <div className="text-center">
-            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-lg flex items-center justify-center">
-              <div className="w-8 h-4 bg-gray-300 rounded"></div>
+            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-lg flex items-center justify-center">
+              <div className="w-8 h-4 bg-muted-foreground rounded"></div>
             </div>
             <p>No data available</p>
           </div>
@@ -250,7 +250,7 @@ export function RefinedAreaChart({ data, title }: RefinedAreaChartProps) {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <h3 className="text-lg font-semibold ">{title}</h3>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>

--- a/components/refined-date-picker.tsx
+++ b/components/refined-date-picker.tsx
@@ -59,47 +59,47 @@ export function RefinedDatePicker({ from, to, onDateChange }: RefinedDatePickerP
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
       <div className="flex flex-col gap-2 w-full sm:w-auto">
-        <label className="text-sm font-medium text-gray-700">From</label>
+        <label className="text-sm font-medium">From</label>
         <div className="flex gap-2">
           <Input
             type="date"
             value={fromInput}
             onChange={(e) => handleFromInputChange(e.target.value)}
-            className="w-40 bg-white/60 border-gray-200/50 hover:bg-white/80"
+            className="w-40"
             placeholder="YYYY-MM-DD"
           />
           <Popover open={fromOpen} onOpenChange={setFromOpen}>
             <PopoverTrigger asChild>
-              <Button variant="outline" size="icon" className="bg-white/60 border-gray-200/50 hover:bg-white/80">
-                <CalendarIcon className="h-4 w-4 text-gray-500" />
+              <Button variant="outline" size="icon">
+                <CalendarIcon className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-auto p-0 bg-white/95 backdrop-blur-sm" align="start">
+            <PopoverContent className="w-auto p-0" align="start">
               <Calendar mode="single" selected={from} onSelect={handleFromCalendarSelect} initialFocus />
             </PopoverContent>
           </Popover>
         </div>
       </div>
 
-      <div className="text-gray-400 hidden sm:block mt-6">to</div>
+      <div className="text-muted-foreground hidden sm:block mt-6">to</div>
 
       <div className="flex flex-col gap-2 w-full sm:w-auto">
-        <label className="text-sm font-medium text-gray-700">To</label>
+        <label className="text-sm font-medium">To</label>
         <div className="flex gap-2">
           <Input
             type="date"
             value={toInput}
             onChange={(e) => handleToInputChange(e.target.value)}
-            className="w-40 bg-white/60 border-gray-200/50 hover:bg-white/80"
+            className="w-40"
             placeholder="YYYY-MM-DD"
           />
           <Popover open={toOpen} onOpenChange={setToOpen}>
             <PopoverTrigger asChild>
-              <Button variant="outline" size="icon" className="bg-white/60 border-gray-200/50 hover:bg-white/80">
-                <CalendarIcon className="h-4 w-4 text-gray-500" />
+              <Button variant="outline" size="icon">
+                <CalendarIcon className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-auto p-0 bg-white/95 backdrop-blur-sm" align="start">
+            <PopoverContent className="w-auto p-0" align="start">
               <Calendar mode="single" selected={to} onSelect={handleToCalendarSelect} initialFocus />
             </PopoverContent>
           </Popover>

--- a/components/working-charts.tsx
+++ b/components/working-charts.tsx
@@ -22,12 +22,12 @@ export function WorkingChart({ data, title, type }: WorkingChartProps) {
 
   if (!data || data.length === 0) {
     return (
-      <Card className="bg-white shadow-lg">
+      <Card className="bg-card shadow-lg">
         <CardHeader>
           <CardTitle>{title}</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="h-80 flex items-center justify-center text-gray-500">
+          <div className="h-80 flex items-center justify-center text-muted-foreground">
             <p>No data available</p>
           </div>
         </CardContent>
@@ -36,7 +36,7 @@ export function WorkingChart({ data, title, type }: WorkingChartProps) {
   }
 
   return (
-    <Card className="bg-white shadow-lg">
+    <Card className="bg-card shadow-lg">
       <CardHeader>
         <CardTitle>{title}</CardTitle>
       </CardHeader>


### PR DESCRIPTION
## Summary
- support dark/light theme in header, footer, and several widgets
- remove hard-coded colors from date pickers and charts

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd248eb1c832cbb72847b07f42b63