### PR TITLE
Fix React key warnings

### DIFF
--- a/app/(protected)/alphanames/[id]/page.tsx
+++ b/app/(protected)/alphanames/[id]/page.tsx
@@ -204,8 +204,8 @@ export default function AlphanameDetailPage() {
                   <SelectValue placeholder="Выберите CTN" />
                 </SelectTrigger>
                 <SelectContent>
-                  {ctnOptions.map(opt => (
-                    <SelectItem value={opt} key={opt}>{opt}</SelectItem>
+                  {ctnOptions.map((opt, index) => (
+                    <SelectItem value={opt} key={`${opt}-${index}`}>{opt}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>

--- a/app/(protected)/alphanames/new/page.tsx
+++ b/app/(protected)/alphanames/new/page.tsx
@@ -199,8 +199,8 @@ export default function AlphanameDetailPage() {
                   <SelectValue placeholder="Выберите Alpha Name" />
                 </SelectTrigger>
                 <SelectContent>
-                  {alphaNameOptions.map(opt => (
-                    <SelectItem value={opt} key={opt}>{opt}</SelectItem>
+                  {alphaNameOptions.map((opt, index) => (
+                    <SelectItem value={opt} key={`${opt}-${index}`}>{opt}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
@@ -215,8 +215,8 @@ export default function AlphanameDetailPage() {
                   <SelectValue placeholder="Выберите CTN" />
                 </SelectTrigger>
                 <SelectContent>
-                  {ctnOptions.map(opt => (
-                    <SelectItem value={opt} key={opt}>{opt}</SelectItem>
+                  {ctnOptions.map((opt, index) => (
+                    <SelectItem value={opt} key={`${opt}-${index}`}>{opt}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>


### PR DESCRIPTION
## Summary
- ensure unique keys for `<SelectItem>` elements on alphaname forms

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685bd16e9c5c832ca56157f7bf4a9896