### PR TITLE
Update Short Numbers form fields

### DIFF
--- a/app/(protected)/short-numbers/[id]/page.tsx
+++ b/app/(protected)/short-numbers/[id]/page.tsx
@@ -197,6 +197,38 @@ export default function ShortNumberDetailPage() {
               onChange={(e) => setItem({ ...item, description: e.target.value })}
             />
           </div>
+          <div className="space-y-2">
+            <Label htmlFor="created">Created</Label>
+            <Input
+              id="created"
+              value={item.created}
+              onChange={(e) => setItem({ ...item, created: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="modified">Modified</Label>
+            <Input
+              id="modified"
+              value={item.modified}
+              onChange={(e) => setItem({ ...item, modified: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="created_by">Created By</Label>
+            <Input
+              id="created_by"
+              value={item.created_by}
+              onChange={(e) => setItem({ ...item, created_by: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="updated_by">Updated By</Label>
+            <Input
+              id="updated_by"
+              value={item.updated_by}
+              onChange={(e) => setItem({ ...item, updated_by: e.target.value })}
+            />
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- extend Short Numbers detail page with fields for `created`, `modified`, `created_by`, and `updated_by`

## Testing
- `npm run lint` *(fails: prompts for eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685bdadff304832cad110ec56306e92e