### PR TITLE
Add ID field to Spam form

### DIFF
--- a/app/(protected)/spams/[id]/page.tsx
+++ b/app/(protected)/spams/[id]/page.tsx
@@ -114,6 +114,15 @@ export default function SpamDetailPage() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
+            <Label htmlFor="id">ID</Label>
+            <Input
+              id="id"
+              value={item.id}
+              onChange={(e) => setItem({ ...item!, id: e.target.value })}
+              disabled={params.id !== "new"}
+            />
+          </div>
+          <div className="space-y-2">
             <Label htmlFor="content">Content</Label>
             <Input
               id="content"


### PR DESCRIPTION
## Summary
- include an editable ID field in the Spam detail form

## Testing
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_685bdae2c180832ca8d5c4c88dbae329