### PR TITLE
Add spam pattern pages

### DIFF
--- a/app/(protected)/spams/[id]/page.tsx
+++ b/app/(protected)/spams/[id]/page.tsx
@@ -2,12 +2,23 @@
 
 import { useRouter, useParams } from "next/navigation"
 import { useEffect, useState } from "react"
-import { ArrowLeft, Save } from "lucide-react"
+import { ArrowLeft, Save, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { ActionButton } from "@/components/common/action-button"
 import { LoadingSpinner } from "@/components/common/loading-spinner"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import type { Spam } from "@/lib/api/spams"
 import { spamsAPI } from "@/lib/api/spams"
 
@@ -18,11 +29,20 @@ export default function SpamDetailPage() {
   const [item, setItem] = useState<Spam | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (params.id === "new") {
-      setItem({ id: "", content: "", source: "", detected_at: "", status: "" })
+      setItem({
+        id: "",
+        regex: "",
+        name: "",
+        active: false,
+        description: "",
+        created: "",
+        modified: "",
+      })
       setLoading(false)
       return
     }
@@ -47,6 +67,19 @@ export default function SpamDetailPage() {
       setError("Failed to save")
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!item || params.id === "new") return
+    setDeleting(true)
+    try {
+      await spamsAPI.delete(item.id)
+      router.push("/spams")
+    } catch (e) {
+      setError("Failed to delete")
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -95,10 +128,33 @@ export default function SpamDetailPage() {
         </ActionButton>
         <div className="flex-1">
           <h1 className="text-3xl font-bold">
-            {params.id === "new" ? "Create Spam" : "Edit Spam"}
+            {params.id === "new" ? "Create Spam Pattern" : "Edit Spam Pattern"}
           </h1>
         </div>
         <div className="flex gap-2">
+          {params.id !== "new" && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <ActionButton variant="destructive" icon={Trash2}>
+                  Delete
+                </ActionButton>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone. This will permanently delete the spam pattern.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
+                    {deleting ? "Deleting..." : "Delete"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
           <ActionButton onClick={handleSave} icon={Save} disabled={saving}>
             {saving ? "Saving..." : "Save"}
           </ActionButton>
@@ -109,49 +165,40 @@ export default function SpamDetailPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Spam Details</CardTitle>
+          <CardTitle>Spam Pattern Details</CardTitle>
           <CardDescription>ID: {item.id || "new"}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="id">ID</Label>
+            <Label htmlFor="regex">Regex</Label>
             <Input
-              id="id"
-              value={item.id}
-              onChange={(e) => setItem({ ...item!, id: e.target.value })}
-              disabled={params.id !== "new"}
+              id="regex"
+              value={item.regex}
+              onChange={(e) => setItem({ ...item!, regex: e.target.value })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="content">Content</Label>
+            <Label htmlFor="name">Name</Label>
             <Input
-              id="content"
-              value={item.content}
-              onChange={(e) => setItem({ ...item!, content: e.target.value })}
+              id="name"
+              value={item.name}
+              onChange={(e) => setItem({ ...item!, name: e.target.value })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="source">Source</Label>
+            <Label htmlFor="active">Active</Label>
             <Input
-              id="source"
-              value={item.source}
-              onChange={(e) => setItem({ ...item!, source: e.target.value })}
+              id="active"
+              value={String(item.active)}
+              onChange={(e) => setItem({ ...item!, active: e.target.value })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="detected_at">Detected At</Label>
+            <Label htmlFor="description">Description</Label>
             <Input
-              id="detected_at"
-              value={item.detected_at}
-              onChange={(e) => setItem({ ...item!, detected_at: e.target.value })}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="status">Status</Label>
-            <Input
-              id="status"
-              value={item.status}
-              onChange={(e) => setItem({ ...item!, status: e.target.value })}
+              id="description"
+              value={item.description}
+              onChange={(e) => setItem({ ...item!, description: e.target.value })}
             />
           </div>
         </CardContent>

--- a/app/(protected)/spams/page.tsx
+++ b/app/(protected)/spams/page.tsx
@@ -9,19 +9,28 @@ import type { Spam } from "@/lib/api/spams"
 import { spamsAPI } from "@/lib/api/spams"
 
 const columns = [
-  { key: "id", label: "ID" },
-  { key: "content", label: "CONTENT", render: (value: string) => value.substring(0, 50) + "..." },
-  { key: "source", label: "SOURCE" },
+  { key: "regex", label: "REGEX" },
+  { key: "name", label: "NAME" },
   {
-    key: "detected_at",
-    label: "DETECTED AT",
-    render: (value: string) => new Date(value).toLocaleString(),
+    key: "active",
+    label: "ACTIVE",
+    render: (v: boolean) => (v ? "Yes" : "No"),
   },
-  { key: "status", label: "STATUS" },
+  { key: "description", label: "DESCRIPTION" },
+  {
+    key: "created",
+    label: "CREATED",
+    render: (v: string) => new Date(v).toLocaleString(),
+  },
+  {
+    key: "modified",
+    label: "MODIFIED",
+    render: (v: string) => new Date(v).toLocaleString(),
+  },
 ]
 
 const filters = {
-  status: ["blocked", "quarantined", "reviewed"],
+  active: ["Yes", "No"],
 }
 
 export default function SpamsPage() {
@@ -50,7 +59,7 @@ export default function SpamsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Spams"
-        description="Detected spam messages and content"
+        description="Spam regex patterns"
         action={{ label: "Add Spam", onClick: handleAdd, icon: Plus }}
       />
 
@@ -59,7 +68,7 @@ export default function SpamsPage() {
         data={data}
         isLoading={loading}
         onRowClick={handleRowClick}
-        searchPlaceholder="Search spam content..."
+        searchPlaceholder="Search spam patterns..."
         filters={filters}
       />
       {error && <div className="text-red-600">{error}</div>}

--- a/lib/api/spams.ts
+++ b/lib/api/spams.ts
@@ -2,19 +2,23 @@
 
 export type Spam = {
   id: string
-  content: string
-  source: string
-  detected_at: string
-  status: string
+  regex: string
+  name: string
+  active: boolean | string
+  description: string
+  created: string
+  modified: string
 }
 
 const mockSpams: Spam[] = [
   {
     id: "1",
-    content: "spam message",
-    source: "user",
-    detected_at: "2024-01-01",
-    status: "new",
+    regex: "^spam$",
+    name: "Spam pattern",
+    active: true,
+    description: "Mock spam regex",
+    created: "2024-01-01",
+    modified: "2024-01-02",
   },
 ]
 
@@ -26,6 +30,8 @@ export const spamsAPI = {
   create: async (_data: Partial<Spam>) => Promise.resolve({ status: 200 }),
   // update: (id: string, data: Partial<Spam>) => fetchProtected(`/admin/main/spammodel/${id}/`, { method: "PUT", body: JSON.stringify(data) }),
   update: async (_id: string, _data: Partial<Spam>) => Promise.resolve({ status: 200 }),
+  // delete: (id: string) => fetchProtected(`/admin/main/spammodel/${id}/`, { method: "DELETE" }),
+  delete: async (_id: string) => Promise.resolve({ status: 200 }),
 }
 
 /*


### PR DESCRIPTION
## Summary
- update spam API to return regex patterns
- list spam regex patterns on `/spams`
- allow creating, updating and deleting spam patterns

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685be3c3f174832c96f0e413d79340c6