### PR TITLE
fix horizontal table scrolling

### DIFF
--- a/components/common/data-table.tsx
+++ b/components/common/data-table.tsx
@@ -88,7 +88,7 @@ export function DataTable({
       </div>
 
       {/* Table */}
-      <div className="rounded-lg border bg-card">
+      <div className="w-full rounded-lg border bg-card overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow className="hover:bg-muted">

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,10 +6,10 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-x-auto">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn("min-w-full caption-bottom text-sm", className)}
       {...props}
     />
   </div>


### PR DESCRIPTION
## Summary
- make `<DataTable>` container full width and horizontally scrollable
- allow table to expand beyond container using `min-w-full`

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_685be84e6090832c864bc6ad0ac736f1