### PR TITLE
Fix table scrolling

### DIFF
--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -9,7 +9,10 @@ const Table = React.forwardRef<
   <div className="relative w-full overflow-x-auto">
     <table
       ref={ref}
-      className={cn("min-w-full caption-bottom text-sm", className)}
+      className={cn(
+        "min-w-full table-fixed caption-bottom text-sm",
+        className
+      )}
       {...props}
     />
   </div>


### PR DESCRIPTION
## Summary
- restore div wrapper so horizontal overflow only affects the table
- make table use `min-w-full` with fixed layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ccf212dcc832ca17b8066a9ecd3dd